### PR TITLE
Initial support for LSP completion snippets

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -199,7 +199,7 @@ export class LanguageServerClient {
                 completion: {
                     dynamicRegistration: true,
                     completionItem: {
-                        snippetSupport: false,
+                        snippetSupport: true,
                         commitCharactersSupport: true,
                         documentationFormat: ["markdown", "plaintext"],
                         deprecatedSupport: false,


### PR DESCRIPTION
This allows basic use of completion snippets, for example on the video below the the cursor is correctly placed within the parentheses:

#### Before

[before.webm](https://github.com/user-attachments/assets/e58fe13b-51a6-4d8d-9eb4-eed68f09aeb4)

####  After

[cursor-goes-within-parens.webm](https://github.com/user-attachments/assets/55ab213d-06d6-4452-933d-90eec395fac6)
