### PR TITLE
allow adding autocomplete from other extensions

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1698,6 +1698,7 @@ export function languageServerWithClient(options: LanguageServerOptions) {
                             result,
                         );
                     },
+                    ...(options.completionConfig?.override || []),
                 ],
             }),
         );


### PR DESCRIPTION
This fixes an issue where other completion sources get overridden by `codemirror-languageserver`.

For context, we just started using `@marimo-team/codemirror-languageserver` for our text editor in Beekeeper Studio. And we use `@codemirror/lang-sql` to get the autocomplete options. Luckily, it has helpers to build the completion sources. I feel like there is a better way to add autocomplete options without overriding other sources, but for now, using the `override` option is probably enough.

I'll be happy to make a new PR when I find a better solution :)