### PR TITLE
fix: correctly aggregate all diagnostics

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -449,7 +449,7 @@ export class LanguageServerPlugin implements PluginValue {
 
     public destroy() {
         // Clear diagnostics from this plugin when destroying
-        this.setDiagnosticsForThisPlugin([]);
+        this.clearDiagnostics();
         this.client.detachPlugin(this);
     }
 
@@ -700,7 +700,7 @@ export class LanguageServerPlugin implements PluginValue {
         const diagEnabled = this.featureOptions.diagnosticsEnabled;
         if (!diagEnabled) {
             // Clear any existing diagnostics from this plugin if disabled
-            this.setDiagnosticsForThisPlugin([]);
+            this.clearDiagnostics();
             return;
         }
 
@@ -784,6 +784,10 @@ export class LanguageServerPlugin implements PluginValue {
 
         const resolvedDiagnostics = await Promise.all(diagnostics);
         this.setDiagnosticsForThisPlugin(resolvedDiagnostics);
+    }
+
+    private clearDiagnostics() {
+        this.view.dispatch(setDiagnostics(this.view.state, []));
     }
 
     /**


### PR DESCRIPTION
Previously, we filter diagnostics by `pluginId`, however, even with the federated LSP client, we still only have a single plugin, and therefore, a single `pluginId`. This means whenever `PyLSP` sends empty diagnostics, it would overwrite the pre-existing `ty` diagnostics. 

In this PR, we find the source of the incoming diagnostics and add existing diagnostics not from the same source as the incoming diagnostics. This allows us to keep pre-existing diagnostics from other sources while overwriting stale diagnostics.

// cc: @nojaf