### PR TITLE
Refactor LSP code into its own file, allow specifying a custom markdown renderer

### DIFF
--- a/src/__tests__/completion.test.ts
+++ b/src/__tests__/completion.test.ts
@@ -121,6 +121,7 @@ describe("convertCompletionItem", () => {
 
         expect(completion.info).toBeDefined();
         if (completion.info) {
+            // @ts-expect-error
             await completion.info();
             expect(mockResolve).toHaveBeenCalledWith(lspItem);
         }

--- a/src/__tests__/formatContents.test.ts
+++ b/src/__tests__/formatContents.test.ts
@@ -134,4 +134,13 @@ describe("formatContents", () => {
         };
         expect(formatContents(content)).toMatchInlineSnapshot(`""`);
     });
+
+    it("allows specifying a custom markdown renderer", () => {
+        const customRenderer = (markdown: string) => `<p>${markdown}</p>`;
+        const content: LSP.MarkupContent = {
+            kind: "markdown",
+            value: "Custom renderer test",
+        };
+        expect(formatContents(content, customRenderer)).toBe("<p>Custom renderer test</p>");
+    });
 });

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -9,11 +9,8 @@ import type {
     DidOpenTextDocumentParams,
     Hover,
 } from "vscode-languageserver-protocol";
-import {
-    LanguageServerClient,
-    languageServer,
-    languageServerWithClient,
-} from "../plugin";
+import { LanguageServerClient } from "../lsp";
+import { languageServer, languageServerWithClient } from "../plugin";
 import { offsetToPos, posToOffset } from "../utils";
 
 // Mock WebSocket transport
@@ -38,8 +35,7 @@ const createMockClient = (
         initializePromise: Promise.resolve(),
         initialize: vi.fn().mockResolvedValue(undefined),
         close: vi.fn(),
-        attachPlugin: vi.fn(),
-        detachPlugin: vi.fn(),
+        onNotification: vi.fn(),
         textDocumentDidOpen: vi
             .fn()
             .mockResolvedValue({} as DidOpenTextDocumentParams),
@@ -245,13 +241,13 @@ describe("LanguageServer", () => {
                 (ext) => ext && typeof ext === "object" && "create" in ext,
             );
 
-            // Manually create the plugin to trigger attachPlugin
+            // Manually create the plugin to trigger onNotification
             if (viewPluginExt && "create" in viewPluginExt) {
                 // @ts-ignore - We know this is a ViewPlugin
                 viewPluginExt.create(mockView);
 
-                // Now attachPlugin should have been called
-                expect(mockClient.attachPlugin).toHaveBeenCalled();
+                // Now onNotification should have been called
+                expect(mockClient.onNotification).toHaveBeenCalled();
 
                 // This is a simplified test that verifies the callback mechanism works
                 // In a real scenario, the plugin would call textDocumentDefinition and then the callback
@@ -321,13 +317,13 @@ describe("LanguageServer", () => {
                 (ext) => ext && typeof ext === "object" && "create" in ext,
             );
 
-            // Manually create the plugin to trigger attachPlugin
+            // Manually create the plugin to trigger onNotification
             if (viewPluginExt && "create" in viewPluginExt) {
                 // @ts-ignore - We know this is a ViewPlugin
                 viewPluginExt.create(mockView);
 
-                // Now attachPlugin should have been called
-                expect(mockClient.attachPlugin).toHaveBeenCalled();
+                // Now onNotification should have been called
+                expect(mockClient.onNotification).toHaveBeenCalled();
 
                 // This is a simplified test that verifies the callback mechanism works
                 // In a real scenario, the plugin would call textDocumentDefinition and then the callback

--- a/src/__tests__/language-server-plugin.test.ts
+++ b/src/__tests__/language-server-plugin.test.ts
@@ -121,7 +121,7 @@ describe("LanguageServerPlugin", () => {
         mockClient.textDocumentCompletion = vi.fn();
         mockClient.textDocumentDefinition = vi.fn();
         mockClient.completionItemResolve = vi.fn();
-        mockClient.onNotification = vi.fn().mockReturnValue(() => {});
+        mockClient.onNotification = vi.fn().mockReturnValue(() => { });
 
         // Create a mock view
         mockView = new EditorView({
@@ -328,7 +328,7 @@ describe("LanguageServerPlugin", () => {
 
             const consoleSpy = vi
                 .spyOn(console, "error")
-                .mockImplementation(() => {});
+                .mockImplementation(() => { });
 
             const changes: LSP.TextDocumentContentChangeEvent[] = [
                 { text: "new content" },
@@ -635,35 +635,6 @@ describe("LanguageServerPlugin", () => {
             expect(() =>
                 plugin.processNotification(notification),
             ).not.toThrow();
-        });
-    });
-
-    describe("markdownRenderer", () => {
-        it("should render markdown using custom renderer", () => {
-            const plugin = new LanguageServerPlugin({
-                client: mockClient,
-                documentUri: "file:///test.ts",
-                languageId: "typescript",
-                view: mockView,
-                featureOptions,
-                markdownRenderer: (markdown) => `<div>${markdown}</div>`,
-            });
-            const markdown = "This is **bold** text";
-            const rendered = plugin.markdownRenderer(markdown);
-            expect(rendered).toBe("<div>This is **bold** text</div>");
-        });
-
-        it("should use default renderer if none provided", () => {
-            const defaultPlugin = new LanguageServerPlugin({
-                client: mockClient,
-                documentUri: "file:///test.ts",
-                languageId: "typescript",
-                view: mockView,
-                featureOptions,
-            });
-            const markdown = "This is **bold** text";
-            const rendered = defaultPlugin.markdownRenderer(markdown);
-            expect(rendered).toBe("");
         });
     });
 });

--- a/src/__tests__/languageServer.test.ts
+++ b/src/__tests__/languageServer.test.ts
@@ -6,9 +6,8 @@ import type {
     ClientCapabilities,
     WorkspaceEdit,
 } from "vscode-languageserver-protocol";
-import { LanguageServerClient } from "../plugin";
+import { type FeatureOptions, LanguageServerClient } from "../lsp";
 import { LanguageServerPlugin } from "../plugin";
-import type { FeatureOptions } from "../plugin";
 
 class MockTransport extends Transport {
     sendData = vi.fn().mockResolvedValue({});

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -20,6 +20,7 @@ interface ConvertCompletionOptions {
     useSnippetOnCompletion: boolean;
     hasResolveProvider: boolean;
     resolveItem: (item: LSP.CompletionItem) => Promise<LSP.CompletionItem>;
+    markdownRenderer?: (markdown: string) => string;
 }
 
 namespace InsertTextFormat {
@@ -147,9 +148,9 @@ export function convertCompletionItem(
                     return null;
                 }
                 if (options.allowHTMLContent) {
-                    dom.innerHTML = formatContents(content);
+                    dom.innerHTML = formatContents(content, options.markdownRenderer);
                 } else {
-                    dom.textContent = formatContents(content);
+                    dom.textContent = formatContents(content, options.markdownRenderer);
                 }
                 return dom;
             } catch (e) {
@@ -162,9 +163,9 @@ export function convertCompletionItem(
                     const dom = document.createElement("div");
                     dom.classList.add("documentation");
                     if (options.allowHTMLContent) {
-                        dom.innerHTML = formatContents(documentation);
+                        dom.innerHTML = formatContents(documentation, options.markdownRenderer);
                     } else {
-                        dom.textContent = formatContents(documentation);
+                        dom.textContent = formatContents(documentation, options.markdownRenderer);
                     }
                     return dom;
                 }
@@ -177,9 +178,9 @@ export function convertCompletionItem(
             const dom = document.createElement("div");
             dom.classList.add("documentation");
             if (options.allowHTMLContent) {
-                dom.innerHTML = formatContents(documentation);
+                dom.innerHTML = formatContents(documentation, options.markdownRenderer);
             } else {
-                dom.textContent = formatContents(documentation);
+                dom.textContent = formatContents(documentation, options.markdownRenderer);
             }
             return dom;
         };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,9 @@
 export {
-    LanguageServerClient,
     LanguageServerPlugin,
     languageServerWithClient,
     languageServer,
 } from "./plugin.js";
-
+export { LanguageServerClient } from "./lsp.js";
 export {
     languageId,
     documentUri,

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -76,10 +76,10 @@ export interface LanguageServerClientOptions {
      * Can be an object or a function that modifies the default capabilities.
      */
     capabilities?:
-        | LSP.InitializeParams["capabilities"]
-        | ((
-              defaultCapabilities: LSP.InitializeParams["capabilities"],
-          ) => LSP.InitializeParams["capabilities"]);
+    | LSP.InitializeParams["capabilities"]
+    | ((
+        defaultCapabilities: LSP.InitializeParams["capabilities"],
+    ) => LSP.InitializeParams["capabilities"]);
     /** Additional initialization options to send to the language server */
     initializationOptions?: LSP.InitializeParams["initializationOptions"];
     getWorkspaceConfiguration?: (
@@ -185,7 +185,7 @@ export interface LanguageServerOptions extends FeatureOptions {
  */
 export interface LanguageServerWebsocketOptions
     extends Omit<LanguageServerOptions, "client">,
-        Omit<LanguageServerClientOptions, "transport"> {
+    Omit<LanguageServerClientOptions, "transport"> {
     /** WebSocket URI for connecting to the language server */
     serverUri: `ws://${string}` | `wss://${string}`;
 }
@@ -205,7 +205,7 @@ export class LanguageServerClient {
     private initializationOptions: LanguageServerClientOptions["initializationOptions"];
     public clientCapabilities: LanguageServerClientOptions["capabilities"];
 
-    private notificationListeners: ((n: Notification) => void)[] = [];
+    private notificationListeners: Set<(n: Notification) => void> = new Set();
 
     constructor({
         rootUri,
@@ -437,14 +437,9 @@ export class LanguageServerClient {
     }
 
     public onNotification(listener: (n: Notification) => void) {
-        this.notificationListeners.push(listener);
+        this.notificationListeners.add(listener);
 
-        return () => {
-            const index = this.notificationListeners.indexOf(listener);
-            if (index !== -1) {
-                this.notificationListeners.splice(index, 1);
-            }
-        };
+        return () => this.notificationListeners.delete(listener);
     }
 
     protected request<K extends keyof LSPRequestMap>(

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -1,0 +1,468 @@
+import type { autocompletion } from "@codemirror/autocomplete";
+import type { hoverTooltip } from "@codemirror/view";
+import {
+    Client,
+    RequestManager,
+    type WebSocketTransport,
+} from "@open-rpc/client-js";
+import type { Transport } from "@open-rpc/client-js/build/transports/Transport.js";
+import type * as LSP from "vscode-languageserver-protocol";
+
+const TIMEOUT = 10000;
+
+// Client to server then server to client
+export interface LSPRequestMap {
+    initialize: [LSP.InitializeParams, LSP.InitializeResult];
+    "textDocument/hover": [LSP.HoverParams, LSP.Hover];
+    "textDocument/completion": [
+        LSP.CompletionParams,
+        LSP.CompletionItem[] | LSP.CompletionList | null,
+    ];
+    "completionItem/resolve": [LSP.CompletionItem, LSP.CompletionItem];
+    "textDocument/definition": [
+        LSP.DefinitionParams,
+        LSP.Definition | LSP.DefinitionLink[] | null,
+    ];
+    "textDocument/codeAction": [
+        LSP.CodeActionParams,
+        (LSP.Command | LSP.CodeAction)[] | null,
+    ];
+    "textDocument/rename": [LSP.RenameParams, LSP.WorkspaceEdit | null];
+    "textDocument/prepareRename": [
+        LSP.PrepareRenameParams,
+        LSP.Range | LSP.PrepareRenameResult | null,
+    ];
+    "textDocument/signatureHelp": [
+        LSP.SignatureHelpParams,
+        LSP.SignatureHelp | null,
+    ];
+}
+
+// Client to server
+export interface LSPNotifyMap {
+    initialized: LSP.InitializedParams;
+    "textDocument/didChange": LSP.DidChangeTextDocumentParams;
+    "textDocument/didOpen": LSP.DidOpenTextDocumentParams;
+}
+
+// Server to client
+export interface LSPEventMap {
+    "textDocument/publishDiagnostics": LSP.PublishDiagnosticsParams;
+}
+
+export type Notification = {
+    [key in keyof LSPEventMap]: {
+        jsonrpc: "2.0";
+        id?: null | undefined;
+        method: key;
+        params: LSPEventMap[key];
+    };
+}[keyof LSPEventMap];
+
+/**
+ * Options for configuring the language server client
+ */
+export interface LanguageServerClientOptions {
+    /** The root URI of the workspace, used for LSP initialization */
+    rootUri: string;
+    /** List of workspace folders to send to the language server */
+    workspaceFolders: LSP.WorkspaceFolder[] | null;
+    /** Transport mechanism for communicating with the language server */
+    transport: Transport;
+    /** Timeout for requests to the language server */
+    timeout?: number;
+    /**
+     * Client capabilities to send to the server during initialization.
+     * Can be an object or a function that modifies the default capabilities.
+     */
+    capabilities?:
+        | LSP.InitializeParams["capabilities"]
+        | ((
+              defaultCapabilities: LSP.InitializeParams["capabilities"],
+          ) => LSP.InitializeParams["capabilities"]);
+    /** Additional initialization options to send to the language server */
+    initializationOptions?: LSP.InitializeParams["initializationOptions"];
+    getWorkspaceConfiguration?: (
+        params: LSP.ConfigurationParams,
+    ) => LSP.LSPAny[];
+}
+
+/**
+ * Keyboard shortcut configuration for LSP features
+ */
+export interface KeyboardShortcuts {
+    /** Keyboard shortcut for rename operations (default: F2) */
+    rename?: string;
+    /** Keyboard shortcut for go to definition (default: Ctrl/Cmd+Click) */
+    goToDefinition?: string;
+    /** Keyboard shortcut for signature help (default: Ctrl/Cmd+Shift+Space) */
+    signatureHelp?: string;
+}
+
+/**
+ * Result of a definition lookup operation
+ */
+export interface DefinitionResult {
+    /** URI of the target document containing the definition */
+    uri: string;
+    /** Range in the document where the definition is located */
+    range: LSP.Range;
+    /** Whether the definition is in a different file than the current document */
+    isExternalDocument: boolean;
+}
+
+export interface FeatureOptions {
+    /** Whether to enable diagnostic messages (default: true) */
+    diagnosticsEnabled?: boolean;
+    /** Whether to enable hover tooltips (default: true) */
+    hoverEnabled?: boolean;
+    /** Whether to enable code completion (default: true) */
+    completionEnabled?: boolean;
+    /** Whether to enable go-to-definition (default: true) */
+    definitionEnabled?: boolean;
+    /** Whether to enable rename functionality (default: true) */
+    renameEnabled?: boolean;
+    /** Whether to enable code actions (default: true) */
+    codeActionsEnabled?: boolean;
+    /** Whether to enable signature help (default: true) */
+    signatureHelpEnabled?: boolean;
+    /** Whether to show signature help while typing (default: false) */
+    signatureActivateOnTyping?: boolean;
+}
+
+/**
+ * Complete options for configuring the language server integration
+ */
+export interface LanguageServerOptions extends FeatureOptions {
+    /** Pre-configured language server client instance or options */
+    client: LanguageServerClient;
+    /** Whether to allow HTML content in hover tooltips and other UI elements */
+    allowHTMLContent?: boolean;
+    /** Whether to prefer snippet insertion for completions when available */
+    useSnippetOnCompletion?: boolean;
+    /** URI of the current document being edited. If not provided, must be passed via the documentUri facet. */
+    documentUri?: string;
+    /** Language identifier (e.g., 'typescript', 'javascript', etc.). If not provided, must be passed via the languageId facet. */
+    languageId?: string;
+    /** Configuration for keyboard shortcuts */
+    keyboardShortcuts?: KeyboardShortcuts;
+    /** Callback triggered when a go-to-definition action is performed */
+    onGoToDefinition?: (result: DefinitionResult) => void;
+
+    /**
+     * Configuration for the completion feature.
+     * If not provided, the default completion config will be used.
+     */
+    completionConfig?: Parameters<typeof autocompletion>[0];
+    /**
+     * Configuration for the hover feature.
+     * If not provided, the default hover config will be used.
+     */
+    hoverConfig?: Parameters<typeof hoverTooltip>[1];
+
+    /**
+     * Regular expression for determining when to show completions.
+     * Default is to show completions when typing a word, after a dot, or after a slash.
+     */
+    completionMatchBefore?: RegExp;
+
+    /**
+     * Whether to send incremental changes to the language server.
+     * @default true
+     */
+    sendIncrementalChanges?: boolean;
+
+    /**
+     * Specify an alternative renderer for markdown content.
+     * @param markdown Markdown string content.
+     * @returns The rendered HTML content.
+     */
+    markdownRenderer?: (markdown: string) => string;
+}
+
+/**
+ * Options for connecting to a language server via WebSocket
+ */
+export interface LanguageServerWebsocketOptions
+    extends Omit<LanguageServerOptions, "client">,
+        Omit<LanguageServerClientOptions, "transport"> {
+    /** WebSocket URI for connecting to the language server */
+    serverUri: `ws://${string}` | `wss://${string}`;
+}
+
+export class LanguageServerClient {
+    public ready: boolean;
+    public capabilities: LSP.ServerCapabilities | null;
+
+    public initializePromise: Promise<void>;
+    private rootUri: string;
+    private workspaceFolders: LSP.WorkspaceFolder[] | null;
+    private timeout: number;
+
+    private transport: Transport;
+    private requestManager: RequestManager;
+    private client: Client;
+    private initializationOptions: LanguageServerClientOptions["initializationOptions"];
+    public clientCapabilities: LanguageServerClientOptions["capabilities"];
+
+    private notificationListeners: ((n: Notification) => void)[] = [];
+
+    constructor({
+        rootUri,
+        workspaceFolders,
+        transport,
+        initializationOptions,
+        capabilities,
+        timeout = TIMEOUT,
+        getWorkspaceConfiguration,
+    }: LanguageServerClientOptions) {
+        this.rootUri = rootUri;
+        this.workspaceFolders = workspaceFolders;
+        this.transport = transport;
+        this.initializationOptions = initializationOptions;
+        this.clientCapabilities = capabilities;
+        this.timeout = timeout;
+        this.ready = false;
+        this.capabilities = null;
+        this.requestManager = new RequestManager([this.transport]);
+        this.client = new Client(this.requestManager);
+
+        this.client.onNotification((data) => {
+            this.processNotification(data as Notification);
+        });
+
+        const webSocketTransport = this.transport as WebSocketTransport;
+        if (webSocketTransport?.connection) {
+            webSocketTransport.connection.addEventListener(
+                "message",
+                // @ts-ignore
+                (message: { data: string }) => {
+                    const data = JSON.parse(message.data);
+                    if (
+                        data.method === "workspace/configuration" &&
+                        getWorkspaceConfiguration
+                    ) {
+                        webSocketTransport.connection.send(
+                            JSON.stringify({
+                                jsonrpc: "2.0",
+                                id: data.id,
+                                result: getWorkspaceConfiguration(data.params),
+                            }),
+                        );
+                        // XXX(hjr265): Need a better way to do this. Relevant issue:
+                        // https://github.com/FurqanSoftware/codemirror-languageserver/issues/9
+                    } else if (data.method && data.id) {
+                        webSocketTransport.connection.send(
+                            JSON.stringify({
+                                jsonrpc: "2.0",
+                                id: data.id,
+                                result: null,
+                            }),
+                        );
+                    }
+                },
+            );
+        }
+
+        this.initializePromise = this.initialize();
+    }
+
+    protected getInitializationOptions(): LSP.InitializeParams["initializationOptions"] {
+        const defaultClientCapabilities: LSP.ClientCapabilities = {
+            textDocument: {
+                hover: {
+                    dynamicRegistration: true,
+                    contentFormat: ["markdown", "plaintext"],
+                },
+                moniker: {},
+                synchronization: {
+                    dynamicRegistration: true,
+                    willSave: false,
+                    didSave: false,
+                    willSaveWaitUntil: false,
+                },
+                codeAction: {
+                    dynamicRegistration: true,
+                    codeActionLiteralSupport: {
+                        codeActionKind: {
+                            valueSet: [
+                                "",
+                                "quickfix",
+                                "refactor",
+                                "refactor.extract",
+                                "refactor.inline",
+                                "refactor.rewrite",
+                                "source",
+                                "source.organizeImports",
+                            ],
+                        },
+                    },
+                    resolveSupport: {
+                        properties: ["edit"],
+                    },
+                },
+                completion: {
+                    dynamicRegistration: true,
+                    completionItem: {
+                        snippetSupport: true,
+                        commitCharactersSupport: true,
+                        documentationFormat: ["markdown", "plaintext"],
+                        deprecatedSupport: false,
+                        preselectSupport: false,
+                    },
+                    contextSupport: false,
+                },
+                signatureHelp: {
+                    dynamicRegistration: true,
+                    signatureInformation: {
+                        documentationFormat: ["markdown", "plaintext"],
+                    },
+                },
+                declaration: {
+                    dynamicRegistration: true,
+                    linkSupport: true,
+                },
+                definition: {
+                    dynamicRegistration: true,
+                    linkSupport: true,
+                },
+                typeDefinition: {
+                    dynamicRegistration: true,
+                    linkSupport: true,
+                },
+                implementation: {
+                    dynamicRegistration: true,
+                    linkSupport: true,
+                },
+                rename: {
+                    dynamicRegistration: true,
+                    prepareSupport: true,
+                },
+            },
+            workspace: {
+                didChangeConfiguration: {
+                    dynamicRegistration: true,
+                },
+            },
+        };
+
+        const defaultOptions = {
+            capabilities: this.clientCapabilities
+                ? typeof this.clientCapabilities === "function"
+                    ? this.clientCapabilities(defaultClientCapabilities)
+                    : this.clientCapabilities
+                : defaultClientCapabilities,
+            initializationOptions: this.initializationOptions,
+            processId: null,
+            rootUri: this.rootUri,
+            workspaceFolders: this.workspaceFolders,
+        };
+
+        return defaultOptions;
+    }
+
+    public async initialize() {
+        const { capabilities } = await this.request(
+            "initialize",
+            this.getInitializationOptions(),
+            this.timeout * 3,
+        );
+        this.capabilities = capabilities;
+        this.notify("initialized", {});
+        this.ready = true;
+    }
+
+    public close() {
+        this.client.close();
+    }
+
+    public textDocumentDidOpen(params: LSP.DidOpenTextDocumentParams) {
+        return this.notify("textDocument/didOpen", params);
+    }
+
+    public textDocumentDidChange(params: LSP.DidChangeTextDocumentParams) {
+        return this.notify("textDocument/didChange", params);
+    }
+
+    public async textDocumentHover(params: LSP.HoverParams) {
+        return await this.request("textDocument/hover", params, this.timeout);
+    }
+
+    public async textDocumentCompletion(params: LSP.CompletionParams) {
+        return await this.request(
+            "textDocument/completion",
+            params,
+            this.timeout,
+        );
+    }
+
+    public async completionItemResolve(item: LSP.CompletionItem) {
+        return await this.request("completionItem/resolve", item, this.timeout);
+    }
+
+    public async textDocumentDefinition(params: LSP.DefinitionParams) {
+        return await this.request(
+            "textDocument/definition",
+            params,
+            this.timeout,
+        );
+    }
+
+    public async textDocumentCodeAction(params: LSP.CodeActionParams) {
+        return await this.request(
+            "textDocument/codeAction",
+            params,
+            this.timeout,
+        );
+    }
+
+    public async textDocumentRename(params: LSP.RenameParams) {
+        return await this.request("textDocument/rename", params, this.timeout);
+    }
+
+    public async textDocumentPrepareRename(params: LSP.PrepareRenameParams) {
+        return await this.request(
+            "textDocument/prepareRename",
+            params,
+            this.timeout,
+        );
+    }
+
+    public async textDocumentSignatureHelp(params: LSP.SignatureHelpParams) {
+        return await this.request(
+            "textDocument/signatureHelp",
+            params,
+            this.timeout,
+        );
+    }
+
+    public onNotification(listener: (n: Notification) => void) {
+        this.notificationListeners.push(listener);
+
+        return () => {
+            const index = this.notificationListeners.indexOf(listener);
+            if (index !== -1) {
+                this.notificationListeners.splice(index, 1);
+            }
+        };
+    }
+
+    protected request<K extends keyof LSPRequestMap>(
+        method: K,
+        params: LSPRequestMap[K][0],
+        timeout: number,
+    ): Promise<LSPRequestMap[K][1]> {
+        return this.client.request({ method, params }, timeout);
+    }
+
+    protected notify<K extends keyof LSPNotifyMap>(
+        method: K,
+        params: LSPNotifyMap[K],
+    ): Promise<LSPNotifyMap[K]> {
+        return this.client.notify({ method, params });
+    }
+
+    protected processNotification(notification: Notification) {
+        this.notificationListeners.forEach((l) => l(notification));
+    }
+}

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -95,7 +95,6 @@ export class LanguageServerPlugin implements PluginValue {
             onGoToDefinition,
             markdownRenderer = renderMarkdown,
         } = opts;
-
         this.documentVersion = 0;
         this.pluginId = uniqueId();
         this.client = client;
@@ -213,9 +212,9 @@ export class LanguageServerPlugin implements PluginValue {
         const dom = document.createElement("div");
         dom.classList.add("documentation", "cm-lsp-hover-tooltip");
         if (this.allowHTMLContent) {
-            dom.innerHTML = formatContents(contents);
+            dom.innerHTML = formatContents(contents, this.markdownRenderer);
         } else {
-            dom.textContent = formatContents(contents);
+            dom.textContent = formatContents(contents, this.markdownRenderer);
         }
         return {
             pos,
@@ -952,7 +951,7 @@ export class LanguageServerPlugin implements PluginValue {
         docsElement.classList.add("cm-signature-docs");
         docsElement.style.cssText = "margin-top: 4px; color: #666;";
 
-        const formattedContent = formatContents(documentation);
+        const formattedContent = formatContents(documentation, this.markdownRenderer);
 
         if (this.allowHTMLContent) {
             docsElement.innerHTML = formattedContent;
@@ -974,7 +973,7 @@ export class LanguageServerPlugin implements PluginValue {
         paramDocsElement.style.cssText =
             "margin-top: 4px; font-style: italic; border-top: 1px solid #eee; padding-top: 4px;";
 
-        const formattedContent = formatContents(documentation);
+        const formattedContent = formatContents(documentation, this.markdownRenderer);
 
         if (this.allowHTMLContent) {
             paramDocsElement.innerHTML = formattedContent;

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -12,11 +12,7 @@ import {
     hoverTooltip,
     keymap,
 } from "@codemirror/view";
-import {
-    Client,
-    RequestManager,
-    WebSocketTransport,
-} from "@open-rpc/client-js";
+import { WebSocketTransport } from "@open-rpc/client-js";
 import {
     CompletionTriggerKind,
     DiagnosticSeverity,
@@ -28,11 +24,18 @@ import type {
 } from "@codemirror/autocomplete";
 import type { Extension } from "@codemirror/state";
 import type { PluginValue, ViewUpdate } from "@codemirror/view";
-import type { Transport } from "@open-rpc/client-js/build/transports/Transport.js";
 import type * as LSP from "vscode-languageserver-protocol";
 import type { PublishDiagnosticsParams } from "vscode-languageserver-protocol";
 import { convertCompletionItem, sortCompletionItems } from "./completion.js";
 import { documentUri, languageId } from "./config.js";
+import {
+    type DefinitionResult,
+    type FeatureOptions,
+    LanguageServerClient,
+    type LanguageServerOptions,
+    type LanguageServerWebsocketOptions,
+    type Notification,
+} from "./lsp.js";
 import {
     eventsFromChangeSet,
     formatContents,
@@ -45,346 +48,9 @@ import {
     showErrorMessage,
 } from "./utils.js";
 
-const TIMEOUT = 10000;
-
 const logger = console.log;
 
 // https://microsoft.github.io/language-server-protocol/specifications/specification-current/
-
-// Client to server then server to client
-interface LSPRequestMap {
-    initialize: [LSP.InitializeParams, LSP.InitializeResult];
-    "textDocument/hover": [LSP.HoverParams, LSP.Hover];
-    "textDocument/completion": [
-        LSP.CompletionParams,
-        LSP.CompletionItem[] | LSP.CompletionList | null,
-    ];
-    "completionItem/resolve": [LSP.CompletionItem, LSP.CompletionItem];
-    "textDocument/definition": [
-        LSP.DefinitionParams,
-        LSP.Definition | LSP.DefinitionLink[] | null,
-    ];
-    "textDocument/codeAction": [
-        LSP.CodeActionParams,
-        (LSP.Command | LSP.CodeAction)[] | null,
-    ];
-    "textDocument/rename": [LSP.RenameParams, LSP.WorkspaceEdit | null];
-    "textDocument/prepareRename": [
-        LSP.PrepareRenameParams,
-        LSP.Range | LSP.PrepareRenameResult | null,
-    ];
-    "textDocument/signatureHelp": [
-        LSP.SignatureHelpParams,
-        LSP.SignatureHelp | null,
-    ];
-}
-
-// Client to server
-interface LSPNotifyMap {
-    initialized: LSP.InitializedParams;
-    "textDocument/didChange": LSP.DidChangeTextDocumentParams;
-    "textDocument/didOpen": LSP.DidOpenTextDocumentParams;
-}
-
-// Server to client
-interface LSPEventMap {
-    "textDocument/publishDiagnostics": LSP.PublishDiagnosticsParams;
-}
-
-type Notification = {
-    [key in keyof LSPEventMap]: {
-        jsonrpc: "2.0";
-        id?: null | undefined;
-        method: key;
-        params: LSPEventMap[key];
-    };
-}[keyof LSPEventMap];
-
-export class LanguageServerClient {
-    public ready: boolean;
-    public capabilities: LSP.ServerCapabilities | null;
-
-    public initializePromise: Promise<void>;
-    private rootUri: string;
-    private workspaceFolders: LSP.WorkspaceFolder[] | null;
-    private autoClose?: boolean;
-    private timeout: number;
-
-    private transport: Transport;
-    private requestManager: RequestManager;
-    private client: Client;
-    private initializationOptions: LanguageServerClientOptions["initializationOptions"];
-    public clientCapabilities: LanguageServerClientOptions["capabilities"];
-
-    private plugins: LanguageServerPlugin[];
-
-    constructor({
-        rootUri,
-        workspaceFolders,
-        transport,
-        autoClose,
-        initializationOptions,
-        capabilities,
-        timeout = TIMEOUT,
-        getWorkspaceConfiguration,
-    }: LanguageServerClientOptions) {
-        this.rootUri = rootUri;
-        this.workspaceFolders = workspaceFolders;
-        this.transport = transport;
-        this.autoClose = autoClose;
-        this.initializationOptions = initializationOptions;
-        this.clientCapabilities = capabilities;
-        this.timeout = timeout;
-        this.ready = false;
-        this.capabilities = null;
-        this.plugins = [];
-        this.requestManager = new RequestManager([this.transport]);
-        this.client = new Client(this.requestManager);
-
-        this.client.onNotification((data) => {
-            this.processNotification(data as Notification);
-        });
-
-        const webSocketTransport = this.transport as WebSocketTransport;
-        if (webSocketTransport?.connection) {
-            webSocketTransport.connection.addEventListener(
-                "message",
-                (message: { data: string }) => {
-                    const data = JSON.parse(message.data);
-                    if (
-                        data.method === "workspace/configuration" &&
-                        getWorkspaceConfiguration
-                    ) {
-                        webSocketTransport.connection.send(
-                            JSON.stringify({
-                                jsonrpc: "2.0",
-                                id: data.id,
-                                result: getWorkspaceConfiguration(data.params),
-                            }),
-                        );
-                        // XXX(hjr265): Need a better way to do this. Relevant issue:
-                        // https://github.com/FurqanSoftware/codemirror-languageserver/issues/9
-                    } else if (data.method && data.id) {
-                        webSocketTransport.connection.send(
-                            JSON.stringify({
-                                jsonrpc: "2.0",
-                                id: data.id,
-                                result: null,
-                            }),
-                        );
-                    }
-                },
-            );
-        }
-
-        this.initializePromise = this.initialize();
-    }
-
-    protected getInitializationOptions(): LSP.InitializeParams["initializationOptions"] {
-        const defaultClientCapabilities: LSP.ClientCapabilities = {
-            textDocument: {
-                hover: {
-                    dynamicRegistration: true,
-                    contentFormat: ["markdown", "plaintext"],
-                },
-                moniker: {},
-                synchronization: {
-                    dynamicRegistration: true,
-                    willSave: false,
-                    didSave: false,
-                    willSaveWaitUntil: false,
-                },
-                codeAction: {
-                    dynamicRegistration: true,
-                    codeActionLiteralSupport: {
-                        codeActionKind: {
-                            valueSet: [
-                                "",
-                                "quickfix",
-                                "refactor",
-                                "refactor.extract",
-                                "refactor.inline",
-                                "refactor.rewrite",
-                                "source",
-                                "source.organizeImports",
-                            ],
-                        },
-                    },
-                    resolveSupport: {
-                        properties: ["edit"],
-                    },
-                },
-                completion: {
-                    dynamicRegistration: true,
-                    completionItem: {
-                        snippetSupport: true,
-                        commitCharactersSupport: true,
-                        documentationFormat: ["markdown", "plaintext"],
-                        deprecatedSupport: false,
-                        preselectSupport: false,
-                    },
-                    contextSupport: false,
-                },
-                signatureHelp: {
-                    dynamicRegistration: true,
-                    signatureInformation: {
-                        documentationFormat: ["markdown", "plaintext"],
-                    },
-                },
-                declaration: {
-                    dynamicRegistration: true,
-                    linkSupport: true,
-                },
-                definition: {
-                    dynamicRegistration: true,
-                    linkSupport: true,
-                },
-                typeDefinition: {
-                    dynamicRegistration: true,
-                    linkSupport: true,
-                },
-                implementation: {
-                    dynamicRegistration: true,
-                    linkSupport: true,
-                },
-                rename: {
-                    dynamicRegistration: true,
-                    prepareSupport: true,
-                },
-            },
-            workspace: {
-                didChangeConfiguration: {
-                    dynamicRegistration: true,
-                },
-            },
-        };
-
-        const defaultOptions = {
-            capabilities: this.clientCapabilities
-                ? typeof this.clientCapabilities === "function"
-                    ? this.clientCapabilities(defaultClientCapabilities)
-                    : this.clientCapabilities
-                : defaultClientCapabilities,
-            initializationOptions: this.initializationOptions,
-            processId: null,
-            rootUri: this.rootUri,
-            workspaceFolders: this.workspaceFolders,
-        };
-
-        return defaultOptions;
-    }
-
-    public async initialize() {
-        const { capabilities } = await this.request(
-            "initialize",
-            this.getInitializationOptions(),
-            this.timeout * 3,
-        );
-        this.capabilities = capabilities;
-        this.notify("initialized", {});
-        this.ready = true;
-    }
-
-    public close() {
-        this.client.close();
-    }
-
-    public textDocumentDidOpen(params: LSP.DidOpenTextDocumentParams) {
-        return this.notify("textDocument/didOpen", params);
-    }
-
-    public textDocumentDidChange(params: LSP.DidChangeTextDocumentParams) {
-        return this.notify("textDocument/didChange", params);
-    }
-
-    public async textDocumentHover(params: LSP.HoverParams) {
-        return await this.request("textDocument/hover", params, this.timeout);
-    }
-
-    public async textDocumentCompletion(params: LSP.CompletionParams) {
-        return await this.request(
-            "textDocument/completion",
-            params,
-            this.timeout,
-        );
-    }
-
-    public async completionItemResolve(item: LSP.CompletionItem) {
-        return await this.request("completionItem/resolve", item, this.timeout);
-    }
-
-    public async textDocumentDefinition(params: LSP.DefinitionParams) {
-        return await this.request(
-            "textDocument/definition",
-            params,
-            this.timeout,
-        );
-    }
-
-    public async textDocumentCodeAction(params: LSP.CodeActionParams) {
-        return await this.request(
-            "textDocument/codeAction",
-            params,
-            this.timeout,
-        );
-    }
-
-    public async textDocumentRename(params: LSP.RenameParams) {
-        return await this.request("textDocument/rename", params, this.timeout);
-    }
-
-    public async textDocumentPrepareRename(params: LSP.PrepareRenameParams) {
-        return await this.request(
-            "textDocument/prepareRename",
-            params,
-            this.timeout,
-        );
-    }
-
-    public async textDocumentSignatureHelp(params: LSP.SignatureHelpParams) {
-        return await this.request(
-            "textDocument/signatureHelp",
-            params,
-            this.timeout,
-        );
-    }
-
-    public attachPlugin(plugin: LanguageServerPlugin) {
-        this.plugins.push(plugin);
-    }
-
-    public detachPlugin(plugin: LanguageServerPlugin) {
-        const i = this.plugins.indexOf(plugin);
-        if (i === -1) {
-            return;
-        }
-        this.plugins.splice(i, 1);
-        if (this.autoClose) {
-            this.close();
-        }
-    }
-
-    protected request<K extends keyof LSPRequestMap>(
-        method: K,
-        params: LSPRequestMap[K][0],
-        timeout: number,
-    ): Promise<LSPRequestMap[K][1]> {
-        return this.client.request({ method, params }, timeout);
-    }
-
-    protected notify<K extends keyof LSPNotifyMap>(
-        method: K,
-        params: LSPNotifyMap[K],
-    ): Promise<LSPNotifyMap[K]> {
-        return this.client.notify({ method, params });
-    }
-
-    protected processNotification(notification: Notification) {
-        for (const plugin of this.plugins) {
-            plugin.processNotification(notification);
-        }
-    }
-}
 
 function uniqueId() {
     return String(Date.now() + Math.random());
@@ -402,6 +68,8 @@ export class LanguageServerPlugin implements PluginValue {
     public sendIncrementalChanges: boolean;
     public featureOptions: Required<FeatureOptions>;
     public onGoToDefinition: ((result: DefinitionResult) => void) | undefined;
+    public markdownRenderer: (markdown: string) => string;
+    private disposeListener?: () => void;
 
     constructor(opts: {
         client: LanguageServerClient;
@@ -413,6 +81,7 @@ export class LanguageServerPlugin implements PluginValue {
         allowHTMLContent?: boolean;
         useSnippetOnCompletion?: boolean;
         onGoToDefinition?: (result: DefinitionResult) => void;
+        markdownRenderer?: (markdown: string) => string;
     }) {
         const {
             client,
@@ -424,6 +93,7 @@ export class LanguageServerPlugin implements PluginValue {
             allowHTMLContent = false,
             useSnippetOnCompletion = false,
             onGoToDefinition,
+            markdownRenderer = renderMarkdown,
         } = opts;
 
         this.documentVersion = 0;
@@ -437,8 +107,8 @@ export class LanguageServerPlugin implements PluginValue {
         this.sendIncrementalChanges = sendIncrementalChanges;
         this.featureOptions = featureOptions;
         this.onGoToDefinition = onGoToDefinition;
-
-        this.client.attachPlugin(this);
+        this.markdownRenderer = markdownRenderer;
+        this.disposeListener = client.onNotification(this.processNotification);
 
         this.initialize({
             documentText: this.view.state.doc.toString(),
@@ -463,7 +133,7 @@ export class LanguageServerPlugin implements PluginValue {
     }
 
     public destroy() {
-        this.client.detachPlugin(this);
+        this.disposeListener?.();
     }
 
     public async initialize({ documentText }: { documentText: string }) {
@@ -795,7 +465,7 @@ export class LanguageServerPlugin implements PluginValue {
                     message: message,
                     renderMessage: () => {
                         const dom = document.createElement("div");
-                        dom.innerHTML = renderMarkdown(message);
+                        dom.innerHTML = this.markdownRenderer(message);
                         return dom;
                     },
                     source: source || this.languageId,
@@ -1464,132 +1134,6 @@ export class LanguageServerPlugin implements PluginValue {
     }
 }
 
-/**
- * Options for configuring the language server client
- */
-export interface LanguageServerClientOptions {
-    /** The root URI of the workspace, used for LSP initialization */
-    rootUri: string;
-    /** List of workspace folders to send to the language server */
-    workspaceFolders: LSP.WorkspaceFolder[] | null;
-    /** Transport mechanism for communicating with the language server */
-    transport: Transport;
-    /** Whether to automatically close the connection when the editor is destroyed */
-    autoClose?: boolean;
-    /** Timeout for requests to the language server */
-    timeout?: number;
-    /**
-     * Client capabilities to send to the server during initialization.
-     * Can be an object or a function that modifies the default capabilities.
-     */
-    capabilities?:
-        | LSP.InitializeParams["capabilities"]
-        | ((
-              defaultCapabilities: LSP.InitializeParams["capabilities"],
-          ) => LSP.InitializeParams["capabilities"]);
-    /** Additional initialization options to send to the language server */
-    initializationOptions?: LSP.InitializeParams["initializationOptions"];
-    getWorkspaceConfiguration?: (
-        params: LSP.ConfigurationParams,
-    ) => LSP.LSPAny[];
-}
-
-/**
- * Keyboard shortcut configuration for LSP features
- */
-interface KeyboardShortcuts {
-    /** Keyboard shortcut for rename operations (default: F2) */
-    rename?: string;
-    /** Keyboard shortcut for go to definition (default: Ctrl/Cmd+Click) */
-    goToDefinition?: string;
-    /** Keyboard shortcut for signature help (default: Ctrl/Cmd+Shift+Space) */
-    signatureHelp?: string;
-}
-
-/**
- * Result of a definition lookup operation
- */
-interface DefinitionResult {
-    /** URI of the target document containing the definition */
-    uri: string;
-    /** Range in the document where the definition is located */
-    range: LSP.Range;
-    /** Whether the definition is in a different file than the current document */
-    isExternalDocument: boolean;
-}
-
-export interface FeatureOptions {
-    /** Whether to enable diagnostic messages (default: true) */
-    diagnosticsEnabled?: boolean;
-    /** Whether to enable hover tooltips (default: true) */
-    hoverEnabled?: boolean;
-    /** Whether to enable code completion (default: true) */
-    completionEnabled?: boolean;
-    /** Whether to enable go-to-definition (default: true) */
-    definitionEnabled?: boolean;
-    /** Whether to enable rename functionality (default: true) */
-    renameEnabled?: boolean;
-    /** Whether to enable code actions (default: true) */
-    codeActionsEnabled?: boolean;
-    /** Whether to enable signature help (default: true) */
-    signatureHelpEnabled?: boolean;
-    /** Whether to show signature help while typing (default: false) */
-    signatureActivateOnTyping?: boolean;
-}
-
-/**
- * Complete options for configuring the language server integration
- */
-interface LanguageServerOptions extends FeatureOptions {
-    /** Pre-configured language server client instance or options */
-    client: LanguageServerClient;
-    /** Whether to allow HTML content in hover tooltips and other UI elements */
-    allowHTMLContent?: boolean;
-    /** Whether to prefer snippet insertion for completions when available */
-    useSnippetOnCompletion?: boolean;
-    /** URI of the current document being edited. If not provided, must be passed via the documentUri facet. */
-    documentUri?: string;
-    /** Language identifier (e.g., 'typescript', 'javascript', etc.). If not provided, must be passed via the languageId facet. */
-    languageId?: string;
-    /** Configuration for keyboard shortcuts */
-    keyboardShortcuts?: KeyboardShortcuts;
-    /** Callback triggered when a go-to-definition action is performed */
-    onGoToDefinition?: (result: DefinitionResult) => void;
-
-    /**
-     * Configuration for the completion feature.
-     * If not provided, the default completion config will be used.
-     */
-    completionConfig?: Parameters<typeof autocompletion>[0];
-    /**
-     * Configuration for the hover feature.
-     * If not provided, the default hover config will be used.
-     */
-    hoverConfig?: Parameters<typeof hoverTooltip>[1];
-
-    /**
-     * Regular expression for determining when to show completions.
-     * Default is to show completions when typing a word, after a dot, or after a slash.
-     */
-    completionMatchBefore?: RegExp;
-
-    /**
-     * Whether to send incremental changes to the language server.
-     * @default true
-     */
-    sendIncrementalChanges?: boolean;
-}
-
-/**
- * Options for connecting to a language server via WebSocket
- */
-interface LanguageServerWebsocketOptions
-    extends Omit<LanguageServerOptions, "client">,
-        Omit<LanguageServerClientOptions, "transport"> {
-    /** WebSocket URI for connecting to the language server */
-    serverUri: `ws://${string}` | `wss://${string}`;
-}
-
 export function languageServer(options: LanguageServerWebsocketOptions) {
     const { serverUri, ...rest } = options;
     return languageServerWithClient({
@@ -1597,7 +1141,6 @@ export function languageServer(options: LanguageServerWebsocketOptions) {
         client: new LanguageServerClient({
             ...options,
             transport: new WebSocketTransport(serverUri),
-            autoClose: true,
         }),
     });
 }
@@ -1641,6 +1184,7 @@ export function languageServerWithClient(options: LanguageServerOptions) {
                 allowHTMLContent: options.allowHTMLContent,
                 useSnippetOnCompletion: options.useSnippetOnCompletion,
                 onGoToDefinition: options.onGoToDefinition,
+                markdownRenderer: options.markdownRenderer,
             });
             return plugin;
         }),

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -108,7 +108,7 @@ export class LanguageServerPlugin implements PluginValue {
         this.featureOptions = featureOptions;
         this.onGoToDefinition = onGoToDefinition;
         this.markdownRenderer = markdownRenderer;
-        this.disposeListener = client.onNotification(this.processNotification);
+        this.disposeListener = client.onNotification(this.processNotification.bind(this));
 
         this.initialize({
             documentText: this.view.state.doc.toString(),
@@ -268,7 +268,7 @@ export class LanguageServerPlugin implements PluginValue {
         const token = match
             ? context.matchBefore(match)
             : // Fallback to matching any character
-              context.matchBefore(/[a-zA-Z0-9]+/);
+            context.matchBefore(/[a-zA-Z0-9]+/);
         let { pos } = context;
 
         const sortedItems = sortCompletionItems(
@@ -400,12 +400,12 @@ export class LanguageServerPlugin implements PluginValue {
         }
 
         const severityMap: Record<DiagnosticSeverity, Diagnostic["severity"]> =
-            {
-                [DiagnosticSeverity.Error]: "error",
-                [DiagnosticSeverity.Warning]: "warning",
-                [DiagnosticSeverity.Information]: "info",
-                [DiagnosticSeverity.Hint]: "info",
-            };
+        {
+            [DiagnosticSeverity.Error]: "error",
+            [DiagnosticSeverity.Warning]: "warning",
+            [DiagnosticSeverity.Information]: "info",
+            [DiagnosticSeverity.Hint]: "info",
+        };
 
         const diagnostics = params.diagnostics.map(
             async ({ range, message, severity, code, source }) => {
@@ -417,7 +417,7 @@ export class LanguageServerPlugin implements PluginValue {
                     (action): Action => ({
                         name:
                             "command" in action &&
-                            typeof action.command === "object"
+                                typeof action.command === "object"
                                 ? action.command?.title || action.title
                                 : action.title,
                         apply: async () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -63,6 +63,7 @@ export function formatContents(
         | LSP.MarkedString
         | LSP.MarkedString[]
         | undefined,
+    markdownRenderer = renderMarkdown,
 ): string {
     if (!contents) {
         return "";
@@ -70,13 +71,13 @@ export function formatContents(
     if (isLSPMarkupContent(contents)) {
         let value = contents.value;
         if (contents.kind === "markdown") {
-            value = renderMarkdown(value.trim());
+            value = markdownRenderer(value.trim());
         }
         return value;
     }
     if (Array.isArray(contents)) {
         return contents
-            .map((c) => formatContents(c))
+            .map((c) => formatContents(c, markdownRenderer))
             .filter(Boolean)
             .join("\n\n");
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -261,10 +261,20 @@ export function eventsFromChangeSet(
 
     // Sort in reverse order to prevent index shift
     events.sort((a, b) => {
-        if (a.range?.start.line !== b.range?.start.line) {
-            return b.range?.start.line - a.range?.start.line;
+        if (!a.range) return 1;  // Sort `a` after `b`.
+        if (!b.range) return -1; // Sort `b` after `a`.
+
+        const aLine = a.range.start.line ?? -1;
+        const bLine = b.range.start.line ?? -1;
+
+        if (aLine !== bLine) {
+            return bLine - aLine; // Sort by line in descending order.
         }
-        return b.range?.start.character - a.range?.start.character;
+
+        const aChar = a.range.start.character ?? -1;
+        const bChar = b.range.start.character ?? -1;
+
+        return bChar - aChar; // If lines are the same, sort by character in descending order.
     });
     return events;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -261,10 +261,10 @@ export function eventsFromChangeSet(
 
     // Sort in reverse order to prevent index shift
     events.sort((a, b) => {
-        if (a.range!.start.line !== b.range!.start.line) {
-            return b.range!.start.line - a.range!.start.line;
+        if (a.range?.start.line !== b.range?.start.line) {
+            return b.range?.start.line - a.range?.start.line;
         }
-        return b.range!.start.character - a.range!.start.character;
+        return b.range?.start.character - a.range?.start.character;
     });
     return events;
 }


### PR DESCRIPTION
* Extracts `LanguageServerClient` and related types into its own file, `lsp.ts`
* Makes breaking change by removing `attachPlugin/detachPlugin` and using a notification-listener pattern instead (to prevent `lsp.ts` from circularly referencing `plugin.ts`), and updates test accordingly (I could understand this change perhaps not being desired)
* Adds `markdownRenderer` option to allow specifying a custom markdown renderer. I use this so that I can reuse my code highlighter in markdown snippets, for ex: 
<img width="1442" height="358" alt="image" src="https://github.com/user-attachments/assets/43a10b12-f287-402e-a6a3-892a74444a09" />


Happy to make any necessary changes given your feedback!