### PR TITLE
fix: remove seemingly unnecessary and garbage accumulating diagnostic code

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -488,34 +488,8 @@ export class LanguageServerPlugin implements PluginValue {
             return;
         }
 
-        const state = this.view.state;
-
-        // Get current diagnostics from the state
-        const currentDiagnostics: Diagnostic[] = [];
-        forEachDiagnostic(state, (diagnostic) => {
-            currentDiagnostics.push(diagnostic);
-            return true;
-        });
-
-        // Sources
-        const uniqueSources = new Set(
-            newDiagnostics
-                .map((diagnostic) => diagnostic.source)
-                .filter(Boolean),
-        );
-
-        // Filter out diagnostics from the same source
-        const diagnosticsFromOtherSources = newDiagnostics.filter(
-            (diagnostic) => {
-                return !uniqueSources.has(diagnostic.source);
-            },
-        );
-
         this.view.dispatch(
-            setDiagnostics(state, [
-                ...diagnosticsFromOtherSources,
-                ...newDiagnostics,
-            ]),
+            setDiagnostics(this.view.state, newDiagnostics),
         );
     }
 


### PR DESCRIPTION
`currentDiagnostics` doesn't appear to be used for anything, and in my case ballooned memory usage to severage GBs for some reason!

It seems like the intention was to facilitate adding diagnostics from multiple sources (LSPs?), but it doesn't make much sense to me to have one file be processed by multiple language servers simultaneously (though who knows) and given that the code wouldn't function as is (`currentDiagnostics` isn't used) it made sense to me to just remove it altogether until necessary.