### PR TITLE
chore: pin pnpm via packageManager

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -20,8 +20,6 @@ jobs:
 
       - name: ⎔ Setup pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
-        with:
-          version: 9
 
       - name: ⎔ Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
 
       - name: ⎔ Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - name: ⎔ Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,7 @@ jobs:
           fetch-depth: 0
 
       - name: ⎔ Setup pnpm
-        uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3
-        with:
-          version: 9
+        uses: pnpm/action-setup@v4
 
       - name: ⎔ Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,9 +24,7 @@ jobs:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
             - name: ⎔ Setup pnpm
-              uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3
-              with:
-                  version: 9
+              uses: pnpm/action-setup@v4
 
             - name: ⎔ Setup Node.js
               uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
             - name: ⎔ Setup pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
             - name: ⎔ Setup Node.js
               uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
         "url": "git+https://github.com/marimo-team/codemirror-languageserver.git"
     },
     "license": "BSD-3-Clause",
+    "packageManager": "pnpm@10.28.2",
     "peerDependencies": {
         "@codemirror/state": "^6",
         "@codemirror/view": "^6"


### PR DESCRIPTION
Adds `"packageManager": "pnpm@10.28.2"` to `package.json` and drops the redundant `version:` arg from `pnpm/action-setup` in CI.

The action now reads the version from `packageManager`, giving a single source of truth shared between local dev and CI. Matches the convention used in `marimo` and `marimo-lsp`.