### PR TITLE
fix: Allow explicit completion on empty prefix

### DIFF
--- a/src/__tests__/explicitCompletion.test.ts
+++ b/src/__tests__/explicitCompletion.test.ts
@@ -1,0 +1,82 @@
+import {
+    completionStatus,
+    currentCompletions,
+    startCompletion,
+} from "@codemirror/autocomplete";
+import { EditorState, Transaction } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { describe, expect, it, vi } from "vitest";
+import { CompletionTriggerKind } from "vscode-languageserver-protocol";
+import type { LanguageServerClient } from "../lsp.js";
+import { languageServerWithClient } from "../plugin.js";
+
+describe("completion request ordering", () => {
+    it("waits for pending document changes before requesting completion", async () => {
+        const initialText = "from dataclasses import";
+        const text = `${initialText} `;
+        let resolveDocumentChange: (() => void) | undefined;
+        const documentChange = new Promise<void>((resolve) => {
+            resolveDocumentChange = resolve;
+        });
+        const textDocumentCompletion = vi.fn().mockResolvedValue({
+            isIncomplete: false,
+            items: [{ label: "dataclass" }, { label: "field" }],
+        });
+        const client = {
+            ready: true,
+            capabilities: { completionProvider: {} },
+            initializePromise: Promise.resolve(),
+            onNotification: vi.fn().mockReturnValue(() => {}),
+            textDocumentDidOpen: vi.fn().mockResolvedValue(undefined),
+            textDocumentDidChange: vi.fn().mockReturnValue(documentChange),
+            textDocumentDidClose: vi.fn().mockResolvedValue(undefined),
+            textDocumentCompletion,
+            completionItemResolve: vi.fn(),
+        } as unknown as LanguageServerClient;
+        const view = new EditorView({
+            state: EditorState.create({
+                doc: initialText,
+                selection: { anchor: initialText.length },
+                extensions: languageServerWithClient({
+                    client,
+                    documentUri: "file:///test.py",
+                    languageId: "python",
+                    completionConfig: { activateOnTyping: false },
+                    diagnosticsEnabled: false,
+                    hoverEnabled: false,
+                    signatureHelpEnabled: false,
+                }),
+            }),
+        });
+
+        view.dispatch({
+            changes: { from: initialText.length, insert: " " },
+            selection: { anchor: text.length },
+            annotations: Transaction.userEvent.of("input.type"),
+        });
+        expect(startCompletion(view)).toBe(true);
+        await vi.waitFor(() => {
+            expect(client.textDocumentDidChange).toHaveBeenCalledOnce();
+        });
+        await new Promise((resolve) => setTimeout(resolve, 75));
+        expect(textDocumentCompletion).not.toHaveBeenCalled();
+
+        resolveDocumentChange?.();
+        await vi.waitFor(() => {
+            expect(textDocumentCompletion).toHaveBeenCalledWith({
+                textDocument: { uri: "file:///test.py" },
+                position: { line: 0, character: text.length },
+                context: {
+                    triggerKind: CompletionTriggerKind.Invoked,
+                    triggerCharacter: undefined,
+                },
+            });
+            expect(completionStatus(view.state)).toBe("active");
+        });
+        expect(
+            currentCompletions(view.state).map(({ label }) => label),
+        ).toEqual(["dataclass", "field"]);
+
+        view.destroy();
+    });
+});

--- a/src/__tests__/getCompletionTriggerKind.test.ts
+++ b/src/__tests__/getCompletionTriggerKind.test.ts
@@ -59,6 +59,32 @@ describe("getCompletionTriggerKind", () => {
         });
     });
 
+    it.each(["from dataclasses import ", "value = "])(
+        "should return Invoked for explicit completion with an empty prefix in %j",
+        (text) => {
+            const context = createMockContext(text, text.length, true);
+
+            const result = getCompletionTriggerKind(context, [], undefined);
+
+            expect(result).toEqual({
+                triggerKind: CompletionTriggerKind.Invoked,
+                triggerCharacter: undefined,
+            });
+        },
+    );
+
+    it("should bypass a custom match pattern for explicit completion", () => {
+        const text = "from dataclasses import ";
+        const context = createMockContext(text, text.length, true);
+
+        const result = getCompletionTriggerKind(context, [], /@\w+$/);
+
+        expect(result).toEqual({
+            triggerKind: CompletionTriggerKind.Invoked,
+            triggerCharacter: undefined,
+        });
+    });
+
     it("should return Invoked for word completion", () => {
         const context = createMockContext("hello", 5, false);
         const result = getCompletionTriggerKind(
@@ -94,6 +120,15 @@ describe("getCompletionTriggerKind", () => {
             [".", "(", ","],
             undefined,
         );
+
+        expect(result).toBeNull();
+    });
+
+    it("should return null for implicit completion after import whitespace", () => {
+        const text = "from dataclasses import ";
+        const context = createMockContext(text, text.length, false);
+
+        const result = getCompletionTriggerKind(context, [], undefined);
 
         expect(result).toBeNull();
     });

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -100,6 +100,7 @@ const SIGNATURE_TOOLTIP_MAX_LINES_BACK = 20;
 export class LanguageServerPlugin implements PluginValue {
     private documentVersion: number;
     private pluginId: string;
+    private pendingDocumentChanges = new Set<Promise<void>>();
     /**
      * The language server client instance.
      */
@@ -207,10 +208,18 @@ export class LanguageServerPlugin implements PluginValue {
             this.sendIncrementalChanges &&
             syncKind === TextDocumentSyncKind.Incremental
         ) {
-            this.sendChanges(eventsFromChangeSet(doc, changes));
+            this.trackDocumentChanges(eventsFromChangeSet(doc, changes));
         } else {
-            this.sendChanges([{ text: state.doc.toString() }]);
+            this.trackDocumentChanges([{ text: state.doc.toString() }]);
         }
+    }
+
+    private trackDocumentChanges(
+        contentChanges: LSP.TextDocumentContentChangeEvent[],
+    ) {
+        const pending = this.sendChanges(contentChanges);
+        this.pendingDocumentChanges.add(pending);
+        void pending.finally(() => this.pendingDocumentChanges.delete(pending));
     }
 
     public destroy() {
@@ -360,6 +369,9 @@ export class LanguageServerPlugin implements PluginValue {
         if (!this.featureOptions.completionEnabled) {
             return null;
         }
+
+        // Completion requests must observe all preceding document updates.
+        await Promise.all(this.pendingDocumentChanges);
 
         if (
             !(this.client.ready && this.client.capabilities?.completionProvider)
@@ -1638,9 +1650,10 @@ export function getCompletionTriggerKind(
         triggerKind = CompletionTriggerKind.TriggerCharacter;
         triggerCharacter = prevChar;
     }
-    // For manual invocation, only show completions when typing
-    // Use the provided pattern or default to words, dots, commas, or slashes
+    // Implicit completion that wasn't caused by a trigger character requires a
+    // matching prefix. Explicit completion may query with an empty prefix.
     if (
+        !explicit &&
         triggerKind === CompletionTriggerKind.Invoked &&
         !context.matchBefore(matchBeforePattern || /(\w+|\w+\.|\/|,)$/)
     ) {


### PR DESCRIPTION
Addresses #68.

This fix was created with Codex and gpt-5.6-xhigh. It updates the completion mechanism and adds 2 tests.

The identified issue(s) were that (1) completions were not triggered for statements ending in a space (e.g., `from dataclasses import `) even when explicitly invoked and (2) a race condition between CodeMirror and pylsp prevented completion even after fixing (1).

This PR does two things:

1. Allows explicit completions even when the text does not match the regex
2. Tracks document changes and waits for them during completion