### PR TITLE
fix: correctness pass over LSP sync, diagnostics, completion, and rename

### DIFF
--- a/src/__tests__/completion-apply.test.ts
+++ b/src/__tests__/completion-apply.test.ts
@@ -1,0 +1,301 @@
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { describe, expect, it, vi } from "vitest";
+import type * as LSP from "vscode-languageserver-protocol";
+import { convertCompletionItem, sortCompletionItems } from "../completion.js";
+
+function createView(doc: string): EditorView {
+    return new EditorView({
+        state: EditorState.create({ doc }),
+        parent: document.createElement("div"),
+    });
+}
+
+const defaultOptions = {
+    allowHTMLContent: false,
+    useSnippetOnCompletion: false,
+    hasResolveProvider: false,
+    resolveItem: vi.fn(),
+};
+
+describe("convertCompletionItem type mapping", () => {
+    it("does not crash on non-standard completion item kinds", () => {
+        const item: LSP.CompletionItem = {
+            label: "custom",
+            // Servers may send kind values outside the standard 1-25 enum
+            kind: 99 as LSP.CompletionItemKind,
+        };
+        const completion = convertCompletionItem(item, defaultOptions);
+        expect(completion.type).toBeUndefined();
+        expect(completion.label).toBe("custom");
+    });
+});
+
+describe("convertCompletionItem apply", () => {
+    it("applies a plain textEdit", () => {
+        const view = createView("fo");
+        const item: LSP.CompletionItem = {
+            label: "foobar",
+            textEdit: {
+                range: {
+                    start: { line: 0, character: 0 },
+                    end: { line: 0, character: 2 },
+                },
+                newText: "foobar",
+            },
+        };
+        const completion = convertCompletionItem(item, defaultOptions);
+        // biome-ignore lint/suspicious/noExplicitAny: test invokes apply directly
+        (completion.apply as any)(view, completion, 0, 2);
+        expect(view.state.doc.toString()).toBe("foobar");
+    });
+
+    it("expands snippet-format textEdits instead of inserting raw snippet syntax", () => {
+        const view = createView("fo");
+        const item: LSP.CompletionItem = {
+            label: "foo",
+            insertTextFormat: 2, // Snippet
+            textEdit: {
+                range: {
+                    start: { line: 0, character: 0 },
+                    end: { line: 0, character: 2 },
+                },
+                newText: "foo(${1:arg})",
+            },
+        };
+        const completion = convertCompletionItem(item, {
+            ...defaultOptions,
+            useSnippetOnCompletion: true,
+        });
+        // biome-ignore lint/suspicious/noExplicitAny: test invokes apply directly
+        (completion.apply as any)(view, completion, 0, 2);
+        expect(view.state.doc.toString()).toBe("foo(arg)");
+        expect(view.state.doc.toString()).not.toContain("${");
+    });
+
+    it("strips snippet syntax from textEdits when snippet expansion is disabled", () => {
+        const view = createView("fo");
+        const item: LSP.CompletionItem = {
+            label: "foo",
+            insertTextFormat: 2, // Snippet
+            textEdit: {
+                range: {
+                    start: { line: 0, character: 0 },
+                    end: { line: 0, character: 2 },
+                },
+                newText: "foo(${1:arg})$0",
+            },
+        };
+        const completion = convertCompletionItem(item, defaultOptions);
+        // biome-ignore lint/suspicious/noExplicitAny: test invokes apply directly
+        (completion.apply as any)(view, completion, 0, 2);
+        expect(view.state.doc.toString()).toBe("foo(arg)");
+    });
+
+    it("falls back to the completion token range when the textEdit range is invalid", () => {
+        const view = createView("fo");
+        const item: LSP.CompletionItem = {
+            label: "foobar",
+            textEdit: {
+                range: {
+                    // Stale range pointing beyond the current document
+                    start: { line: 0, character: 0 },
+                    end: { line: 5, character: 3 },
+                },
+                newText: "foobar",
+            },
+        };
+        const completion = convertCompletionItem(item, defaultOptions);
+        // biome-ignore lint/suspicious/noExplicitAny: test invokes apply directly
+        (completion.apply as any)(view, completion, 0, 2);
+        expect(view.state.doc.toString()).toBe("foobar");
+    });
+
+    it("applies additionalTextEdits against the pre-completion document", () => {
+        // "f x" -> main edit replaces "f" (0-1) with "foobar" (+5 chars),
+        // additional edit replaces "x" (2-3, pre-insert coordinates) with "imported"
+        const view = createView("f x");
+        const item: LSP.CompletionItem = {
+            label: "foobar",
+            insertText: "foobar",
+            additionalTextEdits: [
+                {
+                    range: {
+                        start: { line: 0, character: 2 },
+                        end: { line: 0, character: 3 },
+                    },
+                    newText: "imported",
+                },
+            ],
+        };
+        const completion = convertCompletionItem(item, defaultOptions);
+        // biome-ignore lint/suspicious/noExplicitAny: test invokes apply directly
+        (completion.apply as any)(view, completion, 0, 1);
+        expect(view.state.doc.toString()).toBe("foobar imported");
+    });
+
+    it("applies the main edit and additionalTextEdits in a single transaction", () => {
+        const view = createView("f x");
+        const dispatchSpy = vi.spyOn(view, "dispatch");
+        const item: LSP.CompletionItem = {
+            label: "foobar",
+            insertText: "foobar",
+            additionalTextEdits: [
+                {
+                    range: {
+                        start: { line: 0, character: 2 },
+                        end: { line: 0, character: 3 },
+                    },
+                    newText: "y",
+                },
+                {
+                    range: {
+                        start: { line: 0, character: 1 },
+                        end: { line: 0, character: 1 },
+                    },
+                    newText: "!",
+                },
+            ],
+        };
+        const completion = convertCompletionItem(item, defaultOptions);
+        // biome-ignore lint/suspicious/noExplicitAny: test invokes apply directly
+        (completion.apply as any)(view, completion, 0, 1);
+        expect(view.state.doc.toString()).toBe("foobar! y");
+        expect(dispatchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("inserts an escaped snippet dollar as literal text (snippet mode)", () => {
+        const view = createView("fo");
+        const item: LSP.CompletionItem = {
+            label: "price",
+            insertTextFormat: 2, // Snippet
+            textEdit: {
+                range: {
+                    start: { line: 0, character: 0 },
+                    end: { line: 0, character: 2 },
+                },
+                // Escaped dollar: literal text, not a tabstop
+                newText: String.raw`\${1:price}`,
+            },
+        };
+        const completion = convertCompletionItem(item, {
+            ...defaultOptions,
+            useSnippetOnCompletion: true,
+        });
+        // biome-ignore lint/suspicious/noExplicitAny: test invokes apply directly
+        (completion.apply as any)(view, completion, 0, 2);
+        expect(view.state.doc.toString()).toBe("${1:price}");
+    });
+
+    it("inserts an escaped snippet dollar as literal text (plain mode)", () => {
+        const view = createView("fo");
+        const item: LSP.CompletionItem = {
+            label: "price",
+            insertTextFormat: 2, // Snippet
+            textEdit: {
+                range: {
+                    start: { line: 0, character: 0 },
+                    end: { line: 0, character: 2 },
+                },
+                newText: String.raw`\${1:price}`,
+            },
+        };
+        const completion = convertCompletionItem(item, defaultOptions);
+        // biome-ignore lint/suspicious/noExplicitAny: test invokes apply directly
+        (completion.apply as any)(view, completion, 0, 2);
+        expect(view.state.doc.toString()).toBe("${1:price}");
+    });
+
+    it("places the cursor right after the completion with additionalTextEdits", () => {
+        const view = createView("f x");
+        const item: LSP.CompletionItem = {
+            label: "foobar",
+            insertText: "foobar",
+            additionalTextEdits: [
+                {
+                    // Import edit before the main edit shifts the main offset
+                    range: {
+                        start: { line: 0, character: 2 },
+                        end: { line: 0, character: 3 },
+                    },
+                    newText: "imported",
+                },
+            ],
+        };
+        const completion = convertCompletionItem(item, defaultOptions);
+        // biome-ignore lint/suspicious/noExplicitAny: test invokes apply directly
+        (completion.apply as any)(view, completion, 0, 1);
+        // "foobar imported" - cursor sits right after "foobar" (offset 6)
+        expect(view.state.doc.toString()).toBe("foobar imported");
+        expect(view.state.selection.main.head).toBe(6);
+    });
+
+    it("applies additionalTextEdits before a snippet expansion", () => {
+        const view = createView("f x");
+        const item: LSP.CompletionItem = {
+            label: "foo",
+            insertText: "foo($1)",
+            insertTextFormat: 2, // Snippet
+            additionalTextEdits: [
+                {
+                    range: {
+                        start: { line: 0, character: 2 },
+                        end: { line: 0, character: 3 },
+                    },
+                    newText: "import",
+                },
+            ],
+        };
+        const completion = convertCompletionItem(item, {
+            ...defaultOptions,
+            useSnippetOnCompletion: true,
+        });
+        // biome-ignore lint/suspicious/noExplicitAny: test invokes apply directly
+        (completion.apply as any)(view, completion, 0, 1);
+        expect(view.state.doc.toString()).toBe("foo() import");
+    });
+
+    it("skips additionalTextEdits with invalid ranges instead of editing offset 0", () => {
+        const view = createView("f x");
+        const item: LSP.CompletionItem = {
+            label: "foobar",
+            insertText: "foobar",
+            additionalTextEdits: [
+                {
+                    range: {
+                        // Stale range beyond the document
+                        start: { line: 9, character: 4 },
+                        end: { line: 9, character: 8 },
+                    },
+                    newText: "bad",
+                },
+            ],
+        };
+        const completion = convertCompletionItem(item, defaultOptions);
+        // biome-ignore lint/suspicious/noExplicitAny: test invokes apply directly
+        (completion.apply as any)(view, completion, 0, 1);
+        expect(view.state.doc.toString()).toBe("foobar x");
+    });
+});
+
+describe("sortCompletionItems with opaque sortText", () => {
+    it("boosts prefix matches by label/filterText, not by sortText", () => {
+        // Pyright-style servers send opaque sort keys; prefix boosting must
+        // compare against what the user actually typed (label/filterText)
+        const items: LSP.CompletionItem[] = [
+            { label: "temp", sortText: "1" },
+            { label: "Test", sortText: "9" },
+        ];
+        const sorted = sortCompletionItems(items, "Te", "javascript");
+        expect(sorted.map((i) => i.label)).toEqual(["Test", "temp"]);
+    });
+
+    it("breaks ties between prefix matches using sortText", () => {
+        const items: LSP.CompletionItem[] = [
+            { label: "test", sortText: "2" },
+            { label: "temp", sortText: "1" },
+        ];
+        const sorted = sortCompletionItems(items, "te", "javascript");
+        expect(sorted.map((i) => i.label)).toEqual(["temp", "test"]);
+    });
+});

--- a/src/__tests__/completion.test.ts
+++ b/src/__tests__/completion.test.ts
@@ -192,9 +192,9 @@ describe("convertCompletionItem", () => {
         const info = completion.info?.();
         expect(info).toBeDefined();
         expect(info?.classList.contains("documentation")).toBe(true);
-        expect(info?.textContent).toContain(
-            "<strong>Test</strong> documentation",
-        );
+        // Raw markdown is shown as text; rendered HTML tags must not leak in
+        expect(info?.textContent).toContain("**Test** documentation");
+        expect(info?.textContent).not.toContain("<strong>");
     });
 
     it("should handle completion item resolution", async () => {
@@ -474,15 +474,22 @@ describe("sortCompletionItems", () => {
 });
 
 describe("convertSnippet", () => {
-    it("should remove backslashes", () => {
-        const input = String.raw`filename\\/filename.txt`;
+    it("should unescape double backslashes to a single backslash", () => {
+        // Per the LSP snippet grammar, `\\` is an escaped literal backslash
+        const input = String.raw`C:\\Users\\name`;
         const result = convertSnippet(input);
-        expect(result).toBe("filename/filename.txt");
+        expect(result).toBe(String.raw`C:\Users\name`);
 
-        // but not single
+        // but literal text is untouched
         const input2 = "filename\n/filename.txt";
         const result2 = convertSnippet(input2);
         expect(result2).toBe("filename\n/filename.txt");
+    });
+
+    it("should treat escaped dollar signs as literal text, not tabstops", () => {
+        const input = String.raw`echo \$1`;
+        const result = convertSnippet(input);
+        expect(result).toBe("echo $1");
     });
 
     it("should convert $1 to ${1}", () => {
@@ -512,5 +519,14 @@ describe("convertSnippet", () => {
         const input = "function() { ${1:default} }";
         const result = convertSnippet(input);
         expect(result).toBe("function() { ${1:default} }");
+    });
+
+    it("keeps an escaped dollar before a brace from becoming a field", () => {
+        // LSP `\${1:price}` is literal text, not a tabstop. CodeMirror only
+        // treats `${...}` as a field, so the brace must be escaped so the
+        // sequence renders as the literal `${1:price}`.
+        const input = String.raw`\${1:price}`;
+        const result = convertSnippet(input);
+        expect(result).toBe(String.raw`$\{1:price}`);
     });
 });

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -1,55 +1,57 @@
+import { EditorState, Prec } from "@codemirror/state";
 import { describe, expect, it } from "vitest";
-import { createUseLastOrThrow, documentUri, languageId } from "../config.js";
+import { createUseFirstOrThrow, documentUri, languageId } from "../config.js";
 
-describe("createUseLastOrThrow", () => {
-    it("should return the last value from an array", () => {
-        const useLastOrThrow = createUseLastOrThrow("Test error");
+describe("createUseFirstOrThrow", () => {
+    it("should return the first (highest-precedence) value from an array", () => {
+        // CodeMirror passes facet inputs ordered highest-precedence first
+        const useFirstOrThrow = createUseFirstOrThrow("Test error");
         const values = ["first", "second", "third"];
 
-        expect(useLastOrThrow(values)).toBe("third");
+        expect(useFirstOrThrow(values)).toBe("first");
     });
 
     it("should return the only value from single-item array", () => {
-        const useLastOrThrow = createUseLastOrThrow("Test error");
+        const useFirstOrThrow = createUseFirstOrThrow("Test error");
         const values = ["single"];
 
-        expect(useLastOrThrow(values)).toBe("single");
+        expect(useFirstOrThrow(values)).toBe("single");
     });
 
     it("should throw custom error for empty array when accessed", () => {
         const customMessage = "Custom error message";
-        const useLastOrThrow = createUseLastOrThrow(customMessage);
+        const useFirstOrThrow = createUseFirstOrThrow(customMessage);
 
-        const result = useLastOrThrow([]);
+        const result = useFirstOrThrow([]);
         // The result is a proxy, accessing any property should throw
         expect(() => result.anyProperty).toThrow(customMessage);
     });
 
     it("should handle undefined values correctly", () => {
-        const useLastOrThrow = createUseLastOrThrow("Test error");
+        const useFirstOrThrow = createUseFirstOrThrow("Test error");
         const values = [undefined, "value", undefined];
 
-        const result = useLastOrThrow(values);
+        const result = useFirstOrThrow(values);
         // undefined triggers the fallback proxy
         expect(() => result.anyProperty).toThrow("Test error");
     });
 
     it("should handle null values correctly", () => {
-        const useLastOrThrow = createUseLastOrThrow("Test error");
+        const useFirstOrThrow = createUseFirstOrThrow("Test error");
         const values = [null, "value", null];
 
-        const result = useLastOrThrow(values);
+        const result = useFirstOrThrow(values);
         // null triggers the fallback proxy
         expect(() => result.anyProperty).toThrow("Test error");
     });
 
     it("should work with different types", () => {
-        const useLastOrThrow = createUseLastOrThrow("Test error");
+        const useFirstOrThrow = createUseFirstOrThrow("Test error");
         const numberValues = [1, 2, 3];
         const objectValues = [{ a: 1 }, { b: 2 }];
 
-        expect(useLastOrThrow(numberValues)).toBe(3);
-        expect(useLastOrThrow(objectValues)).toEqual({ b: 2 });
+        expect(useFirstOrThrow(numberValues)).toBe(1);
+        expect(useFirstOrThrow(objectValues)).toEqual({ a: 1 });
     });
 });
 
@@ -67,13 +69,25 @@ describe("documentUri facet", () => {
         );
     });
 
-    it("should return last value when multiple values provided", () => {
-        const values = [
-            "file:///first.ts",
-            "file:///second.ts",
-            "file:///third.ts",
-        ];
-        expect(documentUri.combine(values)).toBe("file:///third.ts");
+    it("should let a high-precedence value override a default one", () => {
+        const state = EditorState.create({
+            extensions: [
+                documentUri.of("file:///default.ts"),
+                Prec.high(documentUri.of("file:///override.ts")),
+            ],
+        });
+        expect(state.facet(documentUri)).toBe("file:///override.ts");
+    });
+
+    it("should use the first value with equal precedence", () => {
+        // Matches the behavior of built-in facets like EditorState.tabSize
+        const state = EditorState.create({
+            extensions: [
+                documentUri.of("file:///first.ts"),
+                documentUri.of("file:///second.ts"),
+            ],
+        });
+        expect(state.facet(documentUri)).toBe("file:///first.ts");
     });
 });
 
@@ -91,8 +105,13 @@ describe("languageId facet", () => {
         );
     });
 
-    it("should return last value when multiple values provided", () => {
-        const values = ["javascript", "typescript", "python"];
-        expect(languageId.combine(values)).toBe("python");
+    it("should let a high-precedence value override a default one", () => {
+        const state = EditorState.create({
+            extensions: [
+                languageId.of("javascript"),
+                Prec.high(languageId.of("typescript")),
+            ],
+        });
+        expect(state.facet(languageId)).toBe("typescript");
     });
 });

--- a/src/__tests__/formatContents.test.ts
+++ b/src/__tests__/formatContents.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type * as LSP from "vscode-languageserver-protocol";
-import { formatContents } from "../utils";
+import { formatContents, renderDocumentation } from "../utils";
 
 describe("formatContents", () => {
     it("returns empty string for undefined input", () => {
@@ -120,7 +120,9 @@ describe("formatContents", () => {
             { language: "typescript", value: "const x = 1;" },
         ];
         const result = formatContents(contents);
-        expect(result).toMatchInlineSnapshot(`"first string"`);
+        expect(result).toContain("first string");
+        expect(result).toContain('<code class="language-typescript">');
+        expect(result).toContain("const x = 1;");
     });
 
     it("handles empty array", () => {
@@ -132,7 +134,9 @@ describe("formatContents", () => {
             language: "javascript",
             value: "console.log('test');",
         };
-        expect(formatContents(content)).toMatchInlineSnapshot(`""`);
+        const result = formatContents(content);
+        expect(result).toContain('<code class="language-javascript">');
+        expect(result).toContain("console.log");
     });
 
     it("allows specifying a custom markdown renderer", () => {
@@ -144,5 +148,59 @@ describe("formatContents", () => {
         expect(formatContents(content, customRenderer)).toBe(
             "<p>Custom renderer test</p>",
         );
+    });
+});
+
+describe("renderDocumentation", () => {
+    const markdownContent: LSP.MarkupContent = {
+        kind: "markdown",
+        value: "**bold** text",
+    };
+
+    it("renders markdown as HTML when HTML content is allowed", () => {
+        const el = document.createElement("div");
+        renderDocumentation(el, markdownContent, { allowHTMLContent: true });
+        expect(el.innerHTML).toContain("<strong>bold</strong>");
+    });
+
+    it("does not show HTML markup as literal text when HTML is not allowed", () => {
+        const el = document.createElement("div");
+        renderDocumentation(el, markdownContent, { allowHTMLContent: false });
+        // The raw markdown source is shown, never rendered HTML tags as text
+        expect(el.textContent).not.toContain("<p>");
+        expect(el.textContent).not.toContain("<strong>");
+        expect(el.textContent).toContain("bold");
+        // No live HTML elements were created
+        expect(el.querySelector("strong")).toBeNull();
+    });
+
+    it("renders plaintext content as-is in both modes", () => {
+        const content: LSP.MarkupContent = {
+            kind: "plaintext",
+            value: "1 < 2 && 3 > 2",
+        };
+        const plain = document.createElement("div");
+        renderDocumentation(plain, content, { allowHTMLContent: false });
+        expect(plain.textContent).toBe("1 < 2 && 3 > 2");
+    });
+
+    it("shows MarkedString values in plaintext mode", () => {
+        const el = document.createElement("div");
+        renderDocumentation(
+            el,
+            { language: "python", value: "def foo(): ..." },
+            { allowHTMLContent: false },
+        );
+        expect(el.textContent).toContain("def foo(): ...");
+        expect(el.textContent).not.toContain("<code");
+    });
+
+    it("uses a custom markdown renderer when provided", () => {
+        const el = document.createElement("div");
+        renderDocumentation(el, markdownContent, {
+            allowHTMLContent: true,
+            markdownRenderer: (md) => `<custom>${md}</custom>`,
+        });
+        expect(el.innerHTML).toContain("<custom>");
     });
 });

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -75,10 +75,8 @@ describe("LanguageServer", () => {
                 doc.length,
             );
 
-            // Test invalid positions
-            expect(
-                posToOffset(doc, { line: 0, character: 50 }),
-            ).toBeUndefined();
+            // Character overflow clamps to the end of the line (LSP spec)
+            expect(posToOffset(doc, { line: 0, character: 50 })).toBe(10);
         });
 
         it("should convert offset to position correctly", async () => {

--- a/src/__tests__/language-server-plugin.test.ts
+++ b/src/__tests__/language-server-plugin.test.ts
@@ -40,6 +40,10 @@ vi.mock("../utils.js", () => ({
     }),
     eventsFromChangeSet: vi.fn().mockReturnValue([]),
     renderMarkdown: vi.fn().mockReturnValue(""),
+    renderDocumentation: vi.fn().mockImplementation((element, contents) => {
+        element.textContent =
+            typeof contents === "string" ? contents : (contents?.value ?? "");
+    }),
     showErrorMessage: vi.fn(),
 }));
 
@@ -660,7 +664,7 @@ describe("LanguageServerPlugin", () => {
 
         it("includes the diagnostic code in the source when present", async () => {
             const addDiagnosticsSpy = vi
-                .spyOn(plugin as never, "addDiagnostics")
+                .spyOn(plugin as never, "setOwnDiagnostics")
                 .mockImplementation(() => {});
 
             await plugin.processDiagnostics({
@@ -688,7 +692,7 @@ describe("LanguageServerPlugin", () => {
 
         it("leaves the source unchanged when no code is present", async () => {
             const addDiagnosticsSpy = vi
-                .spyOn(plugin as never, "addDiagnostics")
+                .spyOn(plugin as never, "setOwnDiagnostics")
                 .mockImplementation(() => {});
 
             await plugin.processDiagnostics({
@@ -711,7 +715,7 @@ describe("LanguageServerPlugin", () => {
 
         it("falls back to languageId when no source is provided", async () => {
             const addDiagnosticsSpy = vi
-                .spyOn(plugin as never, "addDiagnostics")
+                .spyOn(plugin as never, "setOwnDiagnostics")
                 .mockImplementation(() => {});
 
             await plugin.processDiagnostics({
@@ -734,7 +738,7 @@ describe("LanguageServerPlugin", () => {
 
         it("coerces numeric codes to strings in the source", async () => {
             const addDiagnosticsSpy = vi
-                .spyOn(plugin as never, "addDiagnostics")
+                .spyOn(plugin as never, "setOwnDiagnostics")
                 .mockImplementation(() => {});
 
             await plugin.processDiagnostics({

--- a/src/__tests__/lsp-robustness.test.ts
+++ b/src/__tests__/lsp-robustness.test.ts
@@ -1,0 +1,258 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { LanguageServerClient } from "../lsp.js";
+
+// biome-ignore lint/suspicious/noExplicitAny: test helpers
+const clientInstances: any[] = [];
+let failInitialize = false;
+
+vi.mock("@open-rpc/client-js", () => ({
+    Client: vi.fn().mockImplementation(() => {
+        const instance = {
+            request: vi
+                .fn()
+                .mockImplementation(() =>
+                    failInitialize
+                        ? Promise.reject(new Error("server down"))
+                        : Promise.resolve({ capabilities: {} }),
+                ),
+            notify: vi.fn().mockResolvedValue(undefined),
+            close: vi.fn(),
+            onNotification: vi.fn(),
+        };
+        clientInstances.push(instance);
+        return instance;
+    }),
+    RequestManager: vi.fn(),
+}));
+
+interface FakeConnection {
+    handlers: Record<string, (message: { data: unknown }) => void>;
+    addEventListener: ReturnType<typeof vi.fn>;
+    removeEventListener: ReturnType<typeof vi.fn>;
+    send: ReturnType<typeof vi.fn>;
+}
+
+function createFakeWebSocketTransport() {
+    const connection: FakeConnection = {
+        handlers: {},
+        addEventListener: vi.fn((event: string, handler) => {
+            connection.handlers[event] = handler;
+        }),
+        removeEventListener: vi.fn((event: string) => {
+            delete connection.handlers[event];
+        }),
+        send: vi.fn(),
+    };
+    return {
+        connection,
+        sendData: vi.fn().mockResolvedValue({}),
+        subscribe: vi.fn(),
+        unsubscribe: vi.fn(),
+        connect: vi.fn().mockResolvedValue({}),
+        close: vi.fn(),
+        // biome-ignore lint/suspicious/noExplicitAny: minimal transport stub
+    } as any;
+}
+
+function baseOptions(transport = createFakeWebSocketTransport()) {
+    return {
+        rootUri: "file:///test",
+        workspaceFolders: null,
+        transport,
+    };
+}
+
+async function flushTicks(count = 5) {
+    for (let i = 0; i < count; i++) {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+}
+
+beforeEach(() => {
+    clientInstances.length = 0;
+    failInitialize = false;
+});
+
+describe("initialize failure handling", () => {
+    it("does not produce an unhandled rejection when initialize fails", async () => {
+        const unhandled: unknown[] = [];
+        const onUnhandled = (reason: unknown) => unhandled.push(reason);
+        process.on("unhandledRejection", onUnhandled);
+
+        try {
+            failInitialize = true;
+            const client = new LanguageServerClient(baseOptions());
+
+            await flushTicks();
+            expect(unhandled).toEqual([]);
+            expect(client.ready).toBe(false);
+            // Awaiters still observe the rejection themselves
+            await expect(client.initializePromise).rejects.toThrow(
+                "server down",
+            );
+        } finally {
+            process.off("unhandledRejection", onUnhandled);
+        }
+    });
+
+    it("becomes ready when initialize succeeds", async () => {
+        const client = new LanguageServerClient(baseOptions());
+        await flushTicks();
+        expect(client.ready).toBe(true);
+    });
+});
+
+describe("WebSocket message handling", () => {
+    it("responds to server requests with id 0", async () => {
+        const transport = createFakeWebSocketTransport();
+        new LanguageServerClient(baseOptions(transport));
+        const handler = transport.connection.handlers.message;
+        expect(handler).toBeDefined();
+
+        handler({
+            data: JSON.stringify({
+                jsonrpc: "2.0",
+                id: 0,
+                method: "client/registerCapability",
+                params: {},
+            }),
+        });
+
+        expect(transport.connection.send).toHaveBeenCalledWith(
+            JSON.stringify({ jsonrpc: "2.0", id: 0, result: null }),
+        );
+    });
+
+    it("ignores non-JSON frames without throwing", () => {
+        const transport = createFakeWebSocketTransport();
+        new LanguageServerClient(baseOptions(transport));
+        const handler = transport.connection.handlers.message;
+
+        expect(() => handler({ data: "ping" })).not.toThrow();
+        expect(() => handler({ data: new Blob(["binary"]) })).not.toThrow();
+        expect(transport.connection.send).not.toHaveBeenCalled();
+    });
+
+    it("answers workspace/configuration requests (including id 0)", () => {
+        const transport = createFakeWebSocketTransport();
+        const getWorkspaceConfiguration = vi.fn().mockReturnValue([{ a: 1 }]);
+        new LanguageServerClient({
+            ...baseOptions(transport),
+            getWorkspaceConfiguration,
+        });
+        const handler = transport.connection.handlers.message;
+
+        handler({
+            data: JSON.stringify({
+                jsonrpc: "2.0",
+                id: 0,
+                method: "workspace/configuration",
+                params: { items: [] },
+            }),
+        });
+
+        expect(getWorkspaceConfiguration).toHaveBeenCalledWith({ items: [] });
+        expect(transport.connection.send).toHaveBeenCalledWith(
+            JSON.stringify({ jsonrpc: "2.0", id: 0, result: [{ a: 1 }] }),
+        );
+    });
+
+    it("does not reply to notifications (no id)", () => {
+        const transport = createFakeWebSocketTransport();
+        new LanguageServerClient(baseOptions(transport));
+        const handler = transport.connection.handlers.message;
+
+        handler({
+            data: JSON.stringify({
+                jsonrpc: "2.0",
+                method: "window/logMessage",
+                params: {},
+            }),
+        });
+
+        expect(transport.connection.send).not.toHaveBeenCalled();
+    });
+});
+
+describe("close()", () => {
+    it("marks the client not ready, clears listeners, and detaches the ws handler", async () => {
+        const transport = createFakeWebSocketTransport();
+        const client = new LanguageServerClient(baseOptions(transport));
+        await flushTicks();
+        expect(client.ready).toBe(true);
+
+        const listener = vi.fn();
+        client.onNotification(listener);
+
+        client.close();
+
+        expect(client.ready).toBe(false);
+        expect(transport.connection.removeEventListener).toHaveBeenCalledWith(
+            "message",
+            expect.any(Function),
+        );
+        // biome-ignore lint/suspicious/noExplicitAny: accessing protected member in test
+        (client as any).processNotification({
+            jsonrpc: "2.0",
+            method: "textDocument/publishDiagnostics",
+            params: { uri: "file:///x", diagnostics: [] },
+        });
+        expect(listener).not.toHaveBeenCalled();
+        expect(clientInstances.at(-1).close).toHaveBeenCalled();
+    });
+
+    it("does not send initialized or become ready when closed before initialize resolves", async () => {
+        const client = new LanguageServerClient(baseOptions());
+        const internal = clientInstances.at(-1);
+
+        // Close before the pending initialize response is processed
+        client.close();
+        await flushTicks();
+
+        expect(client.ready).toBe(false);
+        const initializedCalls = internal.notify.mock.calls.filter(
+            // biome-ignore lint/suspicious/noExplicitAny: inspecting mock args
+            (call: any[]) => call[0]?.method === "initialized",
+        );
+        expect(initializedCalls).toHaveLength(0);
+    });
+});
+
+describe("notification listener isolation", () => {
+    it("keeps notifying remaining listeners when one throws", () => {
+        const client = new LanguageServerClient(baseOptions());
+        const bad = vi.fn().mockImplementation(() => {
+            throw new Error("listener failed");
+        });
+        const good = vi.fn();
+        client.onNotification(bad);
+        client.onNotification(good);
+
+        const notification = {
+            jsonrpc: "2.0" as const,
+            method: "textDocument/publishDiagnostics" as const,
+            params: { uri: "file:///x", diagnostics: [] },
+        };
+        expect(() =>
+            // biome-ignore lint/suspicious/noExplicitAny: accessing protected member in test
+            (client as any).processNotification(notification),
+        ).not.toThrow();
+        expect(good).toHaveBeenCalledWith(notification);
+    });
+});
+
+describe("textDocumentDidClose", () => {
+    it("sends a textDocument/didClose notification", async () => {
+        const client = new LanguageServerClient(baseOptions());
+        const internal = clientInstances.at(-1);
+
+        await client.textDocumentDidClose({
+            textDocument: { uri: "file:///x" },
+        });
+
+        expect(internal.notify).toHaveBeenCalledWith({
+            method: "textDocument/didClose",
+            params: { textDocument: { uri: "file:///x" } },
+        });
+    });
+});

--- a/src/__tests__/plugin-behavior.test.ts
+++ b/src/__tests__/plugin-behavior.test.ts
@@ -1,0 +1,519 @@
+import { forEachDiagnostic, setDiagnostics } from "@codemirror/lint";
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type * as LSP from "vscode-languageserver-protocol";
+import type { FeatureOptions, LanguageServerClient } from "../lsp.js";
+import { LanguageServerPlugin } from "../plugin.js";
+
+const featureOptions: Required<FeatureOptions> = {
+    diagnosticsEnabled: true,
+    hoverEnabled: true,
+    completionEnabled: true,
+    definitionEnabled: true,
+    renameEnabled: true,
+    codeActionsEnabled: false,
+    signatureHelpEnabled: true,
+    signatureActivateOnTyping: false,
+    signatureHelpOptions: { position: "below" },
+};
+
+interface FakeClientOverrides {
+    ready?: boolean;
+    capabilities?: LSP.ServerCapabilities;
+    initializePromise?: Promise<void>;
+}
+
+function createFakeClient(overrides: FakeClientOverrides = {}) {
+    return {
+        ready: overrides.ready ?? true,
+        capabilities: overrides.capabilities ?? {
+            hoverProvider: true,
+            renameProvider: true,
+        },
+        initializePromise: overrides.initializePromise ?? Promise.resolve(),
+        onNotification: vi.fn().mockReturnValue(() => {}),
+        textDocumentDidOpen: vi.fn().mockResolvedValue(undefined),
+        textDocumentDidChange: vi.fn().mockResolvedValue(undefined),
+        textDocumentDidClose: vi.fn().mockResolvedValue(undefined),
+        textDocumentCodeAction: vi.fn().mockResolvedValue(null),
+        textDocumentPrepareRename: vi.fn(),
+        textDocumentRename: vi.fn(),
+        // biome-ignore lint/suspicious/noExplicitAny: partial stub of the client
+    } as any as LanguageServerClient;
+}
+
+function createView(doc: string): EditorView {
+    return new EditorView({
+        state: EditorState.create({ doc }),
+        parent: document.createElement("div"),
+    });
+}
+
+function createPlugin(
+    view: EditorView,
+    client = createFakeClient(),
+    options: Partial<
+        ConstructorParameters<typeof LanguageServerPlugin>[0]
+    > = {},
+) {
+    return new LanguageServerPlugin({
+        client,
+        documentUri: "file:///test.ts",
+        languageId: "typescript",
+        view,
+        featureOptions,
+        ...options,
+    });
+}
+
+async function flushTicks(count = 5) {
+    for (let i = 0; i < count; i++) {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+}
+
+function countDiagnostics(view: EditorView): { from: number; to: number }[] {
+    const found: { from: number; to: number }[] = [];
+    forEachDiagnostic(view.state, (_d, from, to) => {
+        found.push({ from, to });
+    });
+    return found;
+}
+
+afterEach(() => {
+    document.body.innerHTML = "";
+});
+
+describe("document open synchronization", () => {
+    it("sends the current document text at didOpen time, not a stale snapshot", async () => {
+        let resolveInit: () => void = () => {};
+        const initializePromise = new Promise<void>((resolve) => {
+            resolveInit = resolve;
+        });
+        const client = createFakeClient({ ready: false, initializePromise });
+        const view = createView("hello");
+        createPlugin(view, client);
+
+        // User types while the server is still initializing
+        view.dispatch({ changes: { from: 5, insert: " world" } });
+
+        // biome-ignore lint/suspicious/noExplicitAny: mutating stub state
+        (client as any).ready = true;
+        resolveInit();
+        await flushTicks();
+
+        expect(client.textDocumentDidOpen).toHaveBeenCalledWith({
+            textDocument: expect.objectContaining({
+                uri: "file:///test.ts",
+                text: "hello world",
+            }),
+        });
+    });
+});
+
+describe("destroy lifecycle", () => {
+    it("sends textDocument/didClose on destroy once the document was opened", async () => {
+        const client = createFakeClient();
+        const view = createView("hello");
+        const plugin = createPlugin(view, client);
+        // Let the initial didOpen complete
+        await flushTicks();
+
+        plugin.destroy();
+
+        expect(client.textDocumentDidClose).toHaveBeenCalledWith({
+            textDocument: { uri: "file:///test.ts" },
+        });
+    });
+
+    it("does not send didClose when destroyed before the document was opened", async () => {
+        let resolveInit: () => void = () => {};
+        const initializePromise = new Promise<void>((resolve) => {
+            resolveInit = resolve;
+        });
+        const client = createFakeClient({ initializePromise });
+        const view = createView("hello");
+        const plugin = createPlugin(view, client);
+
+        // Destroy before initialize (and therefore didOpen) has resolved
+        plugin.destroy();
+        resolveInit();
+        await flushTicks();
+
+        expect(client.textDocumentDidOpen).not.toHaveBeenCalled();
+        expect(client.textDocumentDidClose).not.toHaveBeenCalled();
+    });
+
+    it("does not dispatch diagnostics after destroy", async () => {
+        const client = createFakeClient();
+        const view = createView("hello");
+        const plugin = createPlugin(view, client);
+        const dispatchSpy = vi.spyOn(view, "dispatch");
+
+        const pending = plugin.processDiagnostics({
+            uri: "file:///test.ts",
+            diagnostics: [
+                {
+                    range: {
+                        start: { line: 0, character: 0 },
+                        end: { line: 0, character: 5 },
+                    },
+                    message: "late diagnostic",
+                },
+            ],
+        });
+        plugin.destroy();
+        await pending;
+
+        expect(dispatchSpy).not.toHaveBeenCalled();
+    });
+});
+
+describe("diagnostics processing", () => {
+    it("ignores stale publishes with an older version", async () => {
+        const view = createView("hello");
+        const plugin = createPlugin(view);
+        const range = {
+            start: { line: 0, character: 0 },
+            end: { line: 0, character: 5 },
+        };
+
+        await plugin.processDiagnostics({
+            uri: "file:///test.ts",
+            version: 5,
+            diagnostics: [{ range, message: "current" }],
+        });
+        expect(countDiagnostics(view)).toHaveLength(1);
+
+        await plugin.processDiagnostics({
+            uri: "file:///test.ts",
+            version: 3,
+            diagnostics: [
+                { range, message: "stale one" },
+                { range, message: "stale two" },
+            ],
+        });
+        // The stale publish must not replace the newer diagnostics
+        expect(countDiagnostics(view)).toHaveLength(1);
+    });
+
+    it("drops diagnostics with ranges outside the document instead of anchoring at 0", async () => {
+        const view = createView("hello");
+        const plugin = createPlugin(view);
+
+        await plugin.processDiagnostics({
+            uri: "file:///test.ts",
+            diagnostics: [
+                {
+                    range: {
+                        // Stale range from before the doc shrank
+                        start: { line: 5, character: 2 },
+                        end: { line: 5, character: 8 },
+                    },
+                    message: "stale",
+                },
+                {
+                    range: {
+                        start: { line: 0, character: 1 },
+                        end: { line: 0, character: 3 },
+                    },
+                    message: "valid",
+                },
+            ],
+        });
+
+        const diagnostics = countDiagnostics(view);
+        expect(diagnostics).toEqual([{ from: 1, to: 3 }]);
+    });
+
+    it("drops a batch when the document changes while it is resolving", async () => {
+        const view = createView("hello");
+        const plugin = createPlugin(view);
+        const range = {
+            start: { line: 0, character: 0 },
+            end: { line: 0, character: 5 },
+        };
+
+        const pending = plugin.processDiagnostics({
+            uri: "file:///test.ts",
+            version: 1,
+            diagnostics: [{ range, message: "resolved against old doc" }],
+        });
+        // The user edits before the batch commits, invalidating the snapshot
+        // offsets the diagnostics were resolved against
+        view.dispatch({ changes: { from: 0, to: 5, insert: "hi" } });
+        await pending;
+
+        // Stale batch is dropped rather than marking unrelated text
+        expect(countDiagnostics(view)).toHaveLength(0);
+    });
+
+    it("preserves diagnostics from other sources", async () => {
+        const view = createView("hello");
+        const plugin = createPlugin(view);
+
+        // Another linter's diagnostic already in the editor
+        view.dispatch(
+            setDiagnostics(view.state, [
+                {
+                    from: 0,
+                    to: 2,
+                    severity: "warning",
+                    message: "from another linter",
+                    source: "other-linter",
+                },
+            ]),
+        );
+
+        await plugin.processDiagnostics({
+            uri: "file:///test.ts",
+            version: 1,
+            diagnostics: [
+                {
+                    range: {
+                        start: { line: 0, character: 3 },
+                        end: { line: 0, character: 5 },
+                    },
+                    message: "from lsp",
+                },
+            ],
+        });
+        expect(countDiagnostics(view)).toHaveLength(2);
+
+        // A new publish replaces only this plugin's diagnostics
+        await plugin.processDiagnostics({
+            uri: "file:///test.ts",
+            version: 2,
+            diagnostics: [],
+        });
+        const remaining = countDiagnostics(view);
+        expect(remaining).toEqual([{ from: 0, to: 2 }]);
+    });
+});
+
+function stubCoords(view: EditorView) {
+    // jsdom cannot compute text coordinates
+    vi.spyOn(view, "coordsAtPos").mockReturnValue({
+        left: 0,
+        right: 0,
+        top: 0,
+        bottom: 0,
+    });
+}
+
+describe("rename", () => {
+    it("proceeds with the fallback word range when prepareRename returns defaultBehavior", async () => {
+        const client = createFakeClient();
+        // biome-ignore lint/suspicious/noExplicitAny: stub
+        (client.textDocumentPrepareRename as any).mockResolvedValue({
+            defaultBehavior: true,
+        });
+        const view = createView("hello world");
+        stubCoords(view);
+        const plugin = createPlugin(view, client);
+
+        await plugin.requestRename(view, { line: 0, character: 1 });
+
+        const popup = document.querySelector(".cm-rename-popup");
+        expect(popup).not.toBeNull();
+        const input = popup?.querySelector("input");
+        expect(input?.value).toBe("hello");
+    });
+
+    it("reports an error when prepareRename returns defaultBehavior: false", async () => {
+        const client = createFakeClient();
+        // biome-ignore lint/suspicious/noExplicitAny: stub
+        (client.textDocumentPrepareRename as any).mockResolvedValue({
+            defaultBehavior: false,
+        });
+        const view = createView("hello world");
+        stubCoords(view);
+        const plugin = createPlugin(view, client);
+
+        await plugin.requestRename(view, { line: 0, character: 1 });
+
+        expect(document.querySelector(".cm-rename-popup")).toBeNull();
+    });
+
+    it("returns true after applying a WorkspaceEdit using the changes map", async () => {
+        const view = createView("hello world");
+        const plugin = createPlugin(view);
+
+        // biome-ignore lint/suspicious/noExplicitAny: accessing protected member in test
+        const applied = await (plugin as any).applyRenameEdit(view, {
+            changes: {
+                "file:///test.ts": [
+                    {
+                        range: {
+                            start: { line: 0, character: 0 },
+                            end: { line: 0, character: 5 },
+                        },
+                        newText: "howdy",
+                    },
+                ],
+            },
+        });
+
+        expect(applied).toBe(true);
+        expect(view.state.doc.toString()).toBe("howdy world");
+    });
+});
+
+describe("signature help parameter highlighting", () => {
+    it("highlights the active parameter, not an earlier substring match", () => {
+        const view = createView("sum(1, 2)");
+        const plugin = createPlugin(view);
+
+        // biome-ignore lint/suspicious/noExplicitAny: accessing private member in test
+        const element: HTMLElement = (plugin as any).createSignatureElement(
+            {
+                label: "sum(a, s)",
+                parameters: [{ label: "a" }, { label: "s" }],
+            },
+            1,
+        );
+
+        expect(element.textContent).toBe("sum(a, s)");
+        const highlighted = element.querySelector(".cm-signature-active-param");
+        expect(highlighted?.textContent).toBe("s");
+        // The "s" of "sum" must not be the highlighted one: everything before
+        // the highlight must still contain the full function name
+        expect(element.innerHTML.indexOf("sum(a, ")).toBe(0);
+    });
+
+    it("does not inject HTML from parameter labels", () => {
+        const view = createView("f(x)");
+        const plugin = createPlugin(view, createFakeClient(), {
+            allowHTMLContent: true,
+        });
+
+        // biome-ignore lint/suspicious/noExplicitAny: accessing private member in test
+        const element: HTMLElement = (plugin as any).createSignatureElement(
+            {
+                label: "f(<img src=x onerror=alert(1)>)",
+                parameters: [{ label: "<img src=x onerror=alert(1)>" }],
+            },
+            0,
+        );
+
+        expect(element.querySelector("img")).toBeNull();
+    });
+});
+
+describe("document change synchronization", () => {
+    function fakeUpdate(view: EditorView, prevDoc: string, insert: string) {
+        const prevState = EditorState.create({ doc: prevDoc });
+        const changes = prevState.changes({
+            from: prevDoc.length,
+            insert,
+        });
+        return {
+            state: view.state,
+            docChanged: true,
+            startState: prevState,
+            changes,
+            // biome-ignore lint/suspicious/noExplicitAny: minimal ViewUpdate stub
+        } as any;
+    }
+
+    it("sends full text when the server only supports full sync", () => {
+        const client = createFakeClient({
+            capabilities: { textDocumentSync: 1 },
+        });
+        const view = createView("hello!");
+        const plugin = createPlugin(view, client, {
+            sendIncrementalChanges: true,
+        });
+
+        plugin.update(fakeUpdate(view, "hello", "!"));
+
+        expect(client.textDocumentDidChange).toHaveBeenCalledWith(
+            expect.objectContaining({
+                contentChanges: [{ text: "hello!" }],
+            }),
+        );
+    });
+
+    it("sends incremental changes when the server supports them", () => {
+        const client = createFakeClient({
+            capabilities: { textDocumentSync: 2 },
+        });
+        const view = createView("hello!");
+        const plugin = createPlugin(view, client, {
+            sendIncrementalChanges: true,
+        });
+
+        plugin.update(fakeUpdate(view, "hello", "!"));
+
+        expect(client.textDocumentDidChange).toHaveBeenCalledWith(
+            expect.objectContaining({
+                contentChanges: [
+                    {
+                        range: {
+                            start: { line: 0, character: 5 },
+                            end: { line: 0, character: 5 },
+                        },
+                        text: "!",
+                    },
+                ],
+            }),
+        );
+    });
+
+    it("sends nothing when the server disables sync", () => {
+        const client = createFakeClient({
+            capabilities: { textDocumentSync: 0 },
+        });
+        const view = createView("hello!");
+        const plugin = createPlugin(view, client, {
+            sendIncrementalChanges: true,
+        });
+
+        plugin.update(fakeUpdate(view, "hello", "!"));
+
+        expect(client.textDocumentDidChange).not.toHaveBeenCalled();
+    });
+
+    it("sends nothing when TextDocumentSyncOptions omits change", () => {
+        // Per spec, an omitted `change` means the server wants no change
+        // notifications, even if it opts into openClose
+        const client = createFakeClient({
+            capabilities: { textDocumentSync: { openClose: true } },
+        });
+        const view = createView("hello!");
+        const plugin = createPlugin(view, client, {
+            sendIncrementalChanges: true,
+        });
+
+        plugin.update(fakeUpdate(view, "hello", "!"));
+
+        expect(client.textDocumentDidChange).not.toHaveBeenCalled();
+    });
+
+    it("honors the change kind from TextDocumentSyncOptions", () => {
+        const client = createFakeClient({
+            capabilities: { textDocumentSync: { openClose: true, change: 2 } },
+        });
+        const view = createView("hello!");
+        const plugin = createPlugin(view, client, {
+            sendIncrementalChanges: true,
+        });
+
+        plugin.update(fakeUpdate(view, "hello", "!"));
+
+        expect(client.textDocumentDidChange).toHaveBeenCalledWith(
+            expect.objectContaining({
+                contentChanges: [
+                    {
+                        range: {
+                            start: { line: 0, character: 5 },
+                            end: { line: 0, character: 5 },
+                        },
+                        text: "!",
+                    },
+                ],
+            }),
+        );
+    });
+});

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -1,0 +1,31 @@
+// jsdom does not implement Range.getClientRects / getBoundingClientRect, which
+// CodeMirror calls from its asynchronous layout measurement. Tests that mount a
+// real EditorView schedule a measure via requestAnimationFrame that fires after
+// the test body finishes, so without these stubs the measure throws an
+// unhandled error and fails the run even though every assertion passed.
+if (typeof Range !== "undefined") {
+    if (!Range.prototype.getClientRects) {
+        Range.prototype.getClientRects = () =>
+            ({
+                length: 0,
+                item: () => null,
+                [Symbol.iterator]: function* () {},
+                // biome-ignore lint/suspicious/noExplicitAny: minimal jsdom stub
+            }) as any;
+    }
+    if (!Range.prototype.getBoundingClientRect) {
+        Range.prototype.getBoundingClientRect = () =>
+            ({
+                x: 0,
+                y: 0,
+                width: 0,
+                height: 0,
+                top: 0,
+                left: 0,
+                right: 0,
+                bottom: 0,
+                toJSON: () => ({}),
+                // biome-ignore lint/suspicious/noExplicitAny: minimal jsdom stub
+            }) as any;
+    }
+}

--- a/src/__tests__/signatureHelpTooltipDismissal.test.ts
+++ b/src/__tests__/signatureHelpTooltipDismissal.test.ts
@@ -32,6 +32,10 @@ vi.mock("../utils.js", () => ({
     }),
     eventsFromChangeSet: vi.fn().mockReturnValue([]),
     renderMarkdown: vi.fn().mockReturnValue(""),
+    renderDocumentation: vi.fn().mockImplementation((element, contents) => {
+        element.textContent =
+            typeof contents === "string" ? contents : (contents?.value ?? "");
+    }),
     showErrorMessage: vi.fn(),
 }));
 

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -4,11 +4,10 @@ import type { EditorView } from "@codemirror/view";
 import type * as LSP from "vscode-languageserver-protocol";
 import { CompletionItemKind } from "vscode-languageserver-protocol";
 import {
-    formatContents,
     isEmptyDocumentation,
     isLSPTextEdit,
     posToOffset,
-    posToOffsetOrZero,
+    renderDocumentation,
 } from "./utils.js";
 
 const CompletionItemKindMap = Object.fromEntries(
@@ -29,18 +28,98 @@ namespace InsertTextFormat {
 }
 
 /**
- * Converts an LSP snippet to a CodeMirror snippet
+ * Converts an LSP snippet to a CodeMirror snippet.
+ *
+ * Handles LSP snippet escapes (`\\`, `\$`, `\}`, ...) and converts bare
+ * tabstops like `$1` to CodeMirror's `${1}` (braces are required in CodeMirror
+ * syntax). CodeMirror only treats `${...}` as a field, so an escaped `\$` that
+ * precedes a `{` must have that brace escaped as well, otherwise the literal
+ * text would turn into an active placeholder.
  */
 export function convertSnippet(snippet: string): string {
-    // Remove double backslashes
-    const result = snippet.replaceAll(/\\\\/g, "");
+    let result = "";
+    let i = 0;
+    while (i < snippet.length) {
+        const ch = snippet[i];
+        if (ch === "\\" && i + 1 < snippet.length) {
+            const next = snippet[i + 1];
+            if (next === "$") {
+                // Literal `$`. Escape a following `{` so CodeMirror does not
+                // read the sequence as a field.
+                if (snippet[i + 2] === "{") {
+                    result += "$\\{";
+                    i += 3;
+                } else {
+                    result += "$";
+                    i += 2;
+                }
+            } else if (next === "{" || next === "}") {
+                // Keep as a CodeMirror brace escape
+                result += `\\${next}`;
+                i += 2;
+            } else if (next === "\\") {
+                // Escaped backslash -> a single literal backslash
+                result += "\\";
+                i += 2;
+            } else {
+                // Other escapes (e.g. `\,` `\|`) -> the literal character
+                result += next;
+                i += 2;
+            }
+        } else if (ch === "$") {
+            const digits = /^\d+/.exec(snippet.slice(i + 1));
+            if (digits) {
+                result += `\${${digits[0]}}`;
+                i += 1 + digits[0].length;
+            } else {
+                result += ch;
+                i += 1;
+            }
+        } else {
+            result += ch;
+            i += 1;
+        }
+    }
+    return result;
+}
 
-    // Braces are required in CodeMirror syntax
-    return result.replaceAll(
-        /(\$(\d+))/g,
-        // biome-ignore lint/style/useTemplate: reads better
-        (_match, _p1, p2) => "${" + p2 + "}",
-    );
+/**
+ * Converts an LSP snippet to plain text by dropping tabstops and keeping
+ * placeholder defaults. Used when snippet expansion is disabled. Parses the
+ * LSP snippet directly (rather than the CodeMirror conversion) so escaped
+ * sequences like `\${1:x}` render as their literal text.
+ */
+function convertSnippetToPlainText(snippet: string): string {
+    let result = "";
+    let i = 0;
+    while (i < snippet.length) {
+        const ch = snippet[i];
+        if (ch === "\\" && i + 1 < snippet.length) {
+            // LSP escape -> the literal character
+            result += snippet[i + 1];
+            i += 2;
+        } else if (ch === "$") {
+            const braced = /^\{(\d+)(?::([^}]*))?\}/.exec(snippet.slice(i + 1));
+            if (braced) {
+                // `${n:default}` -> default, `${n}` -> ""
+                result += braced[2] ?? "";
+                i += 1 + braced[0].length;
+            } else {
+                const bare = /^\d+/.exec(snippet.slice(i + 1));
+                if (bare) {
+                    // Bare tabstop `$n` -> ""
+                    i += 1 + bare[0].length;
+                } else {
+                    result += ch;
+                    i += 1;
+                }
+            }
+        } else {
+            result += ch;
+            i += 1;
+        }
+    }
+    return result;
 }
 
 /**
@@ -71,71 +150,111 @@ export function convertCompletionItem(
             from: number,
             to: number,
         ) {
+            const state = view.state;
+
+            // Resolve the main edit range and text. If the server-provided
+            // textEdit range does not resolve to a valid range in the current
+            // document (e.g. it is stale), fall back to the token range
+            // CodeMirror computed.
+            let mainFrom = from;
+            let mainTo = to;
+            let newText = insertText || label;
             if (textEdit && isLSPTextEdit(textEdit)) {
-                view.dispatch(
-                    insertCompletionText(
-                        view.state,
-                        textEdit.newText,
-                        posToOffsetOrZero(view.state.doc, textEdit.range.start),
-                        posToOffsetOrZero(view.state.doc, textEdit.range.end),
-                    ),
-                );
-            } else {
-                if (
-                    insertText &&
-                    insertTextFormat === InsertTextFormat.Snippet &&
-                    options.useSnippetOnCompletion
-                ) {
-                    const applySnippet = snippet(convertSnippet(insertText));
-                    applySnippet(view, null, from, to);
-                } else {
-                    // By default it is PlainText
-                    view.dispatch(
-                        insertCompletionText(
-                            view.state,
-                            insertText || label,
-                            from,
-                            to,
-                        ),
-                    );
+                newText = textEdit.newText;
+                const start = posToOffset(state.doc, textEdit.range.start);
+                const end = posToOffset(state.doc, textEdit.range.end);
+                if (start != null && end != null && start <= end) {
+                    mainFrom = start;
+                    mainTo = end;
                 }
             }
-            if (!additionalTextEdits) {
+
+            // additionalTextEdits refer to the document as it was before the
+            // completion is applied, so resolve their offsets now. Skip edits
+            // that are invalid or overlap the main edit.
+            const additionalChanges: {
+                from: number;
+                to: number;
+                insert: string;
+            }[] = [];
+            for (const edit of additionalTextEdits ?? []) {
+                const editFrom = posToOffset(state.doc, edit.range.start);
+                const editTo = posToOffset(state.doc, edit.range.end);
+                if (editFrom == null || editTo == null || editFrom > editTo) {
+                    continue;
+                }
+                if (editTo > mainFrom && editFrom < mainTo) {
+                    continue;
+                }
+                additionalChanges.push({
+                    from: editFrom,
+                    to: editTo,
+                    insert: edit.newText,
+                });
+            }
+
+            if (
+                insertTextFormat === InsertTextFormat.Snippet &&
+                options.useSnippetOnCompletion
+            ) {
+                let snippetFrom = mainFrom;
+                let snippetTo = mainTo;
+                if (additionalChanges.length > 0) {
+                    // Apply the additional edits first, then map the snippet
+                    // range through them
+                    const changeSet = state.changes(additionalChanges);
+                    view.dispatch({ changes: changeSet });
+                    snippetFrom = changeSet.mapPos(snippetFrom, 1);
+                    snippetTo = changeSet.mapPos(snippetTo, 1);
+                }
+                const applySnippet = snippet(convertSnippet(newText));
+                applySnippet(view, null, snippetFrom, snippetTo);
                 return;
             }
-            const sortedEdits = additionalTextEdits.sort(
-                ({ range: { end: a } }, { range: { end: b } }) => {
-                    if (
-                        posToOffsetOrZero(view.state.doc, a) <
-                        posToOffsetOrZero(view.state.doc, b)
-                    ) {
-                        return 1;
-                    }
-                    if (
-                        posToOffsetOrZero(view.state.doc, a) >
-                        posToOffsetOrZero(view.state.doc, b)
-                    ) {
-                        return -1;
-                    }
-                    return 0;
-                },
-            );
-            for (const textEdit of sortedEdits) {
-                view.dispatch(
-                    view.state.update({
-                        changes: {
-                            from: posToOffsetOrZero(
-                                view.state.doc,
-                                textEdit.range.start,
-                            ),
-                            to: posToOffset(view.state.doc, textEdit.range.end),
-                            insert: textEdit.newText,
-                        },
-                    }),
-                );
+
+            if (insertTextFormat === InsertTextFormat.Snippet) {
+                // Snippet-format text must never be inserted verbatim; keep
+                // the placeholder defaults and drop the tabstop syntax
+                newText = convertSnippetToPlainText(newText);
             }
+
+            if (additionalChanges.length === 0) {
+                view.dispatch(
+                    insertCompletionText(state, newText, mainFrom, mainTo),
+                );
+                return;
+            }
+
+            // Apply the main edit and all additional edits in one transaction
+            const changes = state.changes([
+                { from: mainFrom, to: mainTo, insert: newText },
+                ...additionalChanges,
+            ]);
+            view.dispatch({
+                changes,
+                selection: {
+                    // Map with association -1 so the anchor is the start of the
+                    // inserted text (mapPos(_, 1) would already skip past the
+                    // insertion, double-counting its length); add newText.length
+                    // to land the cursor right after the completion
+                    anchor: changes.mapPos(mainFrom, -1) + newText.length,
+                },
+                userEvent: "input.complete",
+            });
         },
-        type: kind && CompletionItemKindMap[kind].toLowerCase(),
+        type: kind ? CompletionItemKindMap[kind]?.toLowerCase() : undefined,
+    };
+
+    const createDocumentationDom = (
+        content: NonNullable<LSP.CompletionItem["documentation"]>,
+    ) => {
+        const dom = document.createElement("div");
+        dom.classList.add("documentation");
+        renderDocumentation(dom, content, {
+            allowHTMLContent: options.allowHTMLContent,
+            markdownRenderer: options.markdownRenderer,
+        });
+        return dom;
     };
 
     // Support lazy loading of documentation through completionItem/resolve
@@ -143,70 +262,23 @@ export function convertCompletionItem(
         completion.info = async () => {
             try {
                 const resolved = await options.resolveItem?.(item);
-                const dom = document.createElement("div");
-                dom.classList.add("documentation");
                 const content = resolved?.documentation || documentation;
-                if (!content) {
+                if (!content || isEmptyDocumentation(content)) {
                     return null;
                 }
-                if (isEmptyDocumentation(content)) {
-                    return null;
-                }
-                if (options.allowHTMLContent) {
-                    dom.innerHTML = formatContents(
-                        content,
-                        options.markdownRenderer,
-                    );
-                } else {
-                    dom.textContent = formatContents(
-                        content,
-                        options.markdownRenderer,
-                    );
-                }
-                return dom;
+                return createDocumentationDom(content);
             } catch (e) {
                 console.error("Failed to resolve completion item:", e);
-                if (isEmptyDocumentation(documentation)) {
+                // Fallback to existing documentation if resolve fails
+                if (!documentation || isEmptyDocumentation(documentation)) {
                     return null;
                 }
-                // Fallback to existing documentation if resolve fails
-                if (documentation) {
-                    const dom = document.createElement("div");
-                    dom.classList.add("documentation");
-                    if (options.allowHTMLContent) {
-                        dom.innerHTML = formatContents(
-                            documentation,
-                            options.markdownRenderer,
-                        );
-                    } else {
-                        dom.textContent = formatContents(
-                            documentation,
-                            options.markdownRenderer,
-                        );
-                    }
-                    return dom;
-                }
-                return null;
+                return createDocumentationDom(documentation);
             }
         };
     } else if (documentation) {
         // Fallback for servers without resolve support
-        completion.info = () => {
-            const dom = document.createElement("div");
-            dom.classList.add("documentation");
-            if (options.allowHTMLContent) {
-                dom.innerHTML = formatContents(
-                    documentation,
-                    options.markdownRenderer,
-                );
-            } else {
-                dom.textContent = formatContents(
-                    documentation,
-                    options.markdownRenderer,
-                );
-            }
-            return dom;
-        };
+        completion.info = () => createDocumentationDom(documentation);
     }
 
     return completion;
@@ -246,17 +318,21 @@ export function sortCompletionItems(
 
 function prefixSortCompletion(prefix: string) {
     // Sort completion items:
-    // 1. Prioritize items that start with the exact token text
-    // 2. Otherwise maintain original order
+    // 1. Prioritize items whose visible text starts with the exact token
+    //    text (sortText is an opaque server-side sort key, so the prefix is
+    //    matched against filterText/label instead)
+    // 2. Otherwise order by sortText (falling back to label)
     return (a: LSP.CompletionItem, b: LSP.CompletionItem) => {
+        const aMatches = (a.filterText ?? a.label).startsWith(prefix);
+        const bMatches = (b.filterText ?? b.label).startsWith(prefix);
+        if (aMatches && !bMatches) {
+            return -1;
+        }
+        if (!aMatches && bMatches) {
+            return 1;
+        }
         const aText = a.sortText ?? a.label;
         const bText = b.sortText ?? b.label;
-        switch (true) {
-            case aText.startsWith(prefix) && !bText.startsWith(prefix):
-                return -1;
-            case !aText.startsWith(prefix) && bText.startsWith(prefix):
-                return 1;
-        }
         return aText.localeCompare(bText);
     };
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 import { Facet } from "@codemirror/state";
 
-export function createUseLastOrThrow(message: string) {
+export function createUseFirstOrThrow(message: string) {
     const fallback = new Proxy(
         {},
         {
@@ -10,19 +10,21 @@ export function createUseLastOrThrow(message: string) {
         },
     );
 
-    return function useLastOrThrow<T>(values: readonly T[]): T {
-        return values.at(-1) ?? (fallback as T);
+    return function useFirstOrThrow<T>(values: readonly T[]): T {
+        // CodeMirror passes facet inputs ordered highest-precedence first,
+        // so the first value wins (matching built-ins like EditorState.tabSize)
+        return values[0] ?? (fallback as T);
     };
 }
 
 export const documentUri = Facet.define<string, string>({
-    combine: createUseLastOrThrow(
+    combine: createUseFirstOrThrow(
         "No document URI provided. Either pass a one into the extension or use documentUri.of().",
     ),
 });
 
 export const languageId = Facet.define<string, string>({
-    combine: createUseLastOrThrow(
+    combine: createUseFirstOrThrow(
         "No language ID provided. Either pass a one into the extension or use languageId.of().",
     ),
 });

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -43,6 +43,7 @@ export interface LSPNotifyMap {
     initialized: LSP.InitializedParams;
     "textDocument/didChange": LSP.DidChangeTextDocumentParams;
     "textDocument/didOpen": LSP.DidOpenTextDocumentParams;
+    "textDocument/didClose": LSP.DidCloseTextDocumentParams;
 }
 
 // Server to client
@@ -211,6 +212,9 @@ export class LanguageServerClient {
     public clientCapabilities: LanguageServerClientOptions["capabilities"];
 
     private notificationListeners: Set<(n: Notification) => void> = new Set();
+    private webSocketConnection?: WebSocketTransport["connection"];
+    private webSocketMessageHandler?: (message: { data: unknown }) => void;
+    private isClosed = false;
 
     constructor({
         rootUri,
@@ -238,38 +242,61 @@ export class LanguageServerClient {
 
         const webSocketTransport = this.transport as WebSocketTransport;
         if (webSocketTransport?.connection) {
+            this.webSocketConnection = webSocketTransport.connection;
+            this.webSocketMessageHandler = (message: { data: unknown }) => {
+                if (typeof message.data !== "string") {
+                    return;
+                }
+                // biome-ignore lint/suspicious/noExplicitAny: raw JSON-RPC frame
+                let data: any;
+                try {
+                    data = JSON.parse(message.data);
+                } catch {
+                    // Ignore non-JSON frames (e.g. keepalive pings)
+                    return;
+                }
+                if (data == null || typeof data !== "object") {
+                    return;
+                }
+                // A JSON-RPC id of 0 is valid, so check for presence, not truthiness
+                const isRequest = data.id !== undefined && data.id !== null;
+                if (
+                    data.method === "workspace/configuration" &&
+                    isRequest &&
+                    getWorkspaceConfiguration
+                ) {
+                    webSocketTransport.connection.send(
+                        JSON.stringify({
+                            jsonrpc: "2.0",
+                            id: data.id,
+                            result: getWorkspaceConfiguration(data.params),
+                        }),
+                    );
+                    // XXX(hjr265): Need a better way to do this. Relevant issue:
+                    // https://github.com/FurqanSoftware/codemirror-languageserver/issues/9
+                } else if (data.method && isRequest) {
+                    webSocketTransport.connection.send(
+                        JSON.stringify({
+                            jsonrpc: "2.0",
+                            id: data.id,
+                            result: null,
+                        }),
+                    );
+                }
+            };
             webSocketTransport.connection.addEventListener(
                 "message",
                 // @ts-ignore
-                (message: { data: string }) => {
-                    const data = JSON.parse(message.data);
-                    if (
-                        data.method === "workspace/configuration" &&
-                        getWorkspaceConfiguration
-                    ) {
-                        webSocketTransport.connection.send(
-                            JSON.stringify({
-                                jsonrpc: "2.0",
-                                id: data.id,
-                                result: getWorkspaceConfiguration(data.params),
-                            }),
-                        );
-                        // XXX(hjr265): Need a better way to do this. Relevant issue:
-                        // https://github.com/FurqanSoftware/codemirror-languageserver/issues/9
-                    } else if (data.method && data.id) {
-                        webSocketTransport.connection.send(
-                            JSON.stringify({
-                                jsonrpc: "2.0",
-                                id: data.id,
-                                result: null,
-                            }),
-                        );
-                    }
-                },
+                this.webSocketMessageHandler,
             );
         }
 
         this.initializePromise = this.initialize();
+        // Keep a failed initialize from becoming an unhandled rejection;
+        // awaiters of initializePromise still observe the rejection themselves
+        this.initializePromise.catch((error) => {
+            console.error("Language server initialization failed", error);
+        });
     }
 
     protected getInitializationOptions(): LSP.InitializeParams["initializationOptions"] {
@@ -372,12 +399,29 @@ export class LanguageServerClient {
             this.getInitializationOptions(),
             this.timeout * 3,
         );
+        // The client may have been closed while initialize was in flight;
+        // don't send `initialized` on a dead transport or revive `ready`
+        if (this.isClosed) {
+            return;
+        }
         this.capabilities = capabilities;
         this.notify("initialized", {});
         this.ready = true;
     }
 
     public close() {
+        this.isClosed = true;
+        this.ready = false;
+        this.notificationListeners.clear();
+        if (this.webSocketConnection && this.webSocketMessageHandler) {
+            this.webSocketConnection.removeEventListener(
+                "message",
+                // @ts-ignore
+                this.webSocketMessageHandler,
+            );
+            this.webSocketConnection = undefined;
+            this.webSocketMessageHandler = undefined;
+        }
         this.client.close();
     }
 
@@ -387,6 +431,10 @@ export class LanguageServerClient {
 
     public textDocumentDidChange(params: LSP.DidChangeTextDocumentParams) {
         return this.notify("textDocument/didChange", params);
+    }
+
+    public textDocumentDidClose(params: LSP.DidCloseTextDocumentParams) {
+        return this.notify("textDocument/didClose", params);
     }
 
     public async textDocumentHover(params: LSP.HoverParams) {
@@ -464,7 +512,12 @@ export class LanguageServerClient {
 
     protected processNotification(notification: Notification) {
         for (const l of this.notificationListeners) {
-            l(notification);
+            try {
+                l(notification);
+            } catch (error) {
+                // One faulty listener must not starve the others
+                console.error("Notification listener failed", error);
+            }
         }
     }
 }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -17,6 +17,7 @@ import { WebSocketTransport } from "@open-rpc/client-js";
 import {
     CompletionTriggerKind,
     DiagnosticSeverity,
+    TextDocumentSyncKind,
 } from "vscode-languageserver-protocol";
 
 import type {
@@ -44,12 +45,12 @@ import {
 } from "./lsp.js";
 import {
     eventsFromChangeSet,
-    formatContents,
     isEmptyDocumentation,
     offsetToPos,
     posToOffset,
     posToOffsetOrZero,
     prefixMatch,
+    renderDocumentation,
     renderMarkdown,
     showErrorMessage,
 } from "./utils.js";
@@ -140,6 +141,8 @@ export class LanguageServerPlugin implements PluginValue {
      */
     public markdownRenderer: (markdown: string) => string;
     private disposeListener?: () => void;
+    private destroyed = false;
+    private documentOpened = false;
 
     constructor(opts: {
         client: LanguageServerClient;
@@ -181,8 +184,8 @@ export class LanguageServerPlugin implements PluginValue {
             this.processNotification.bind(this),
         );
 
-        this.initialize({
-            documentText: this.view.state.doc.toString(),
+        this.initialize().catch((error) => {
+            console.error("Language server initialization failed", error);
         });
     }
 
@@ -196,7 +199,14 @@ export class LanguageServerPlugin implements PluginValue {
             return;
         }
 
-        if (this.sendIncrementalChanges) {
+        const syncKind = this.resolveTextDocumentSyncKind();
+        if (syncKind === TextDocumentSyncKind.None) {
+            return;
+        }
+        if (
+            this.sendIncrementalChanges &&
+            syncKind === TextDocumentSyncKind.Incremental
+        ) {
             this.sendChanges(eventsFromChangeSet(doc, changes));
         } else {
             this.sendChanges([{ text: state.doc.toString() }]);
@@ -204,21 +214,61 @@ export class LanguageServerPlugin implements PluginValue {
     }
 
     public destroy() {
+        this.destroyed = true;
         this.disposeListener?.();
+        this.disposeListener = undefined;
+        // Only close a document we actually opened - a view torn down during
+        // its initial async tick may never have sent didOpen
+        if (this.documentOpened && this.client.ready) {
+            Promise.resolve(
+                this.client.textDocumentDidClose({
+                    textDocument: { uri: this.documentUri },
+                }),
+            ).catch((error) => {
+                console.error("Failed to send didClose", error);
+            });
+        }
     }
 
-    public async initialize({ documentText }: { documentText: string }) {
+    public async initialize({ documentText }: { documentText?: string } = {}) {
         if (this.client.initializePromise) {
             await this.client.initializePromise;
+        }
+        if (this.destroyed) {
+            return;
         }
         await this.client.textDocumentDidOpen({
             textDocument: {
                 uri: this.documentUri,
                 languageId: this.languageId,
-                text: documentText,
+                // Read the document at didOpen time so edits made while the
+                // server was still initializing are not lost
+                text: documentText ?? this.view.state.doc.toString(),
                 version: this.documentVersion,
             },
         });
+        this.documentOpened = true;
+    }
+
+    /**
+     * The sync kind the server supports; incremental changes may only be
+     * sent when the server announced Incremental sync.
+     */
+    private resolveTextDocumentSyncKind(): TextDocumentSyncKind {
+        const sync = this.client.capabilities?.textDocumentSync;
+        if (sync == null) {
+            // Server did not advertise the capability; honor the
+            // configured behavior
+            return this.sendIncrementalChanges
+                ? TextDocumentSyncKind.Incremental
+                : TextDocumentSyncKind.Full;
+        }
+        if (typeof sync === "number") {
+            return sync;
+        }
+        // Per the LSP spec, an omitted `change` in TextDocumentSyncOptions
+        // means the server wants no change notifications
+        return sync.change ?? TextDocumentSyncKind.None;
     }
 
     public async sendChanges(
@@ -283,11 +333,10 @@ export class LanguageServerPlugin implements PluginValue {
         }
         const dom = document.createElement("div");
         dom.classList.add("documentation", "cm-lsp-hover-tooltip");
-        if (this.allowHTMLContent) {
-            dom.innerHTML = formatContents(contents, this.markdownRenderer);
-        } else {
-            dom.textContent = formatContents(contents, this.markdownRenderer);
-        }
+        renderDocumentation(dom, contents, {
+            allowHTMLContent: this.allowHTMLContent,
+            markdownRenderer: this.markdownRenderer,
+        });
         return {
             pos,
             end,
@@ -455,13 +504,12 @@ export class LanguageServerPlugin implements PluginValue {
             return;
         }
 
-        // If the version is newer, clear the diagnostics and update the last seen version
-        if (
-            params.version != null &&
-            params.version > this.lastSeenDiagnosticsVersion
-        ) {
+        if (params.version != null) {
+            // Ignore stale publishes delivered out of order
+            if (params.version < this.lastSeenDiagnosticsVersion) {
+                return;
+            }
             this.lastSeenDiagnosticsVersion = params.version;
-            this.clearDiagnostics();
         }
 
         // Check if diagnostics are enabled
@@ -480,8 +528,26 @@ export class LanguageServerPlugin implements PluginValue {
                 [DiagnosticSeverity.Hint]: "info",
             };
 
+        // Snapshot the document so ranges are resolved against the text the
+        // server published for, even while code actions load below
+        const doc = this.view.state.doc;
+
         const diagnostics = params.diagnostics.map(
-            async ({ range, message, severity, code, source }) => {
+            async ({
+                range,
+                message,
+                severity,
+                code,
+                source,
+            }): Promise<Diagnostic | null> => {
+                const from = posToOffset(doc, range.start);
+                const to = posToOffset(doc, range.end);
+                if (from == null || to == null || from > to) {
+                    // The range does not exist in this document (e.g. a
+                    // stale publish); dropping it beats misplacing it
+                    return null;
+                }
+
                 const actions = await this.requestCodeActions(range, [
                     code as string,
                 ]);
@@ -502,24 +568,7 @@ export class LanguageServerPlugin implements PluginValue {
                                     return;
                                 }
 
-                                // Apply workspace edit
-                                for (const change of changes) {
-                                    this.view.dispatch(
-                                        this.view.state.update({
-                                            changes: {
-                                                from: posToOffsetOrZero(
-                                                    this.view.state.doc,
-                                                    change.range.start,
-                                                ),
-                                                to: posToOffset(
-                                                    this.view.state.doc,
-                                                    change.range.end,
-                                                ),
-                                                insert: change.newText,
-                                            },
-                                        }),
-                                    );
-                                }
+                                this.applyEdits(this.view, changes);
                             }
 
                             if ("command" in action && action.command) {
@@ -538,13 +587,17 @@ export class LanguageServerPlugin implements PluginValue {
                         : baseSource;
 
                 const diagnostic: Diagnostic = {
-                    from: posToOffsetOrZero(this.view.state.doc, range.start),
-                    to: posToOffsetOrZero(this.view.state.doc, range.end),
+                    from,
+                    to,
                     severity: severityMap[severity ?? DiagnosticSeverity.Error],
                     message: message,
                     renderMessage: () => {
                         const dom = document.createElement("div");
-                        dom.innerHTML = this.markdownRenderer(message);
+                        if (this.allowHTMLContent) {
+                            dom.innerHTML = this.markdownRenderer(message);
+                        } else {
+                            dom.textContent = message;
+                        }
                         return dom;
                     },
                     source: formattedSource,
@@ -557,50 +610,52 @@ export class LanguageServerPlugin implements PluginValue {
         );
 
         const resolvedDiagnostics = await Promise.all(diagnostics);
-        this.addDiagnostics(resolvedDiagnostics);
+        // Bail out if this publish is no longer current. Code actions are
+        // awaited above, so by now the plugin may have been torn down, a newer
+        // publish may have superseded this one, or the document may have
+        // changed - in which case the snapshot offsets are stale and would
+        // mark unrelated text.
+        if (this.destroyed) {
+            return;
+        }
+        if (
+            params.version != null &&
+            params.version < this.lastSeenDiagnosticsVersion
+        ) {
+            return;
+        }
+        if (this.view.state.doc !== doc) {
+            return;
+        }
+        this.setOwnDiagnostics(
+            resolvedDiagnostics.filter(
+                (diagnostic): diagnostic is Diagnostic => diagnostic != null,
+            ),
+        );
     }
 
     /**
-     * Adds diagnostics to the current state
+     * Replaces this plugin's diagnostics while preserving diagnostics
+     * added by other sources (e.g. other plugins or linters)
      */
-    private addDiagnostics(newDiagnostics: Diagnostic[]) {
-        if (newDiagnostics.length === 0) {
-            return;
-        }
-
+    private setOwnDiagnostics(newDiagnostics: Diagnostic[]) {
         const state = this.view.state;
 
-        // Get current diagnostics from the state
-        const currentDiagnostics: Diagnostic[] = [];
-        forEachDiagnostic(state, (diagnostic) => {
-            currentDiagnostics.push(diagnostic);
-            return true;
+        const otherDiagnostics: Diagnostic[] = [];
+        forEachDiagnostic(state, (diagnostic, from, to) => {
+            if (diagnostic.markClass !== this.pluginId) {
+                // Use the mapped positions in case the document changed
+                otherDiagnostics.push({ ...diagnostic, from, to });
+            }
         });
 
-        // Sources
-        const uniqueSources = new Set(
-            newDiagnostics
-                .map((diagnostic) => diagnostic.source)
-                .filter(Boolean),
-        );
-
-        // Filter out diagnostics from the same source
-        const diagnosticsFromOtherSources = newDiagnostics.filter(
-            (diagnostic) => {
-                return !uniqueSources.has(diagnostic.source);
-            },
-        );
-
         this.view.dispatch(
-            setDiagnostics(state, [
-                ...diagnosticsFromOtherSources,
-                ...newDiagnostics,
-            ]),
+            setDiagnostics(state, [...otherDiagnostics, ...newDiagnostics]),
         );
     }
 
     private clearDiagnostics() {
-        this.view.dispatch(setDiagnostics(this.view.state, []));
+        this.setOwnDiagnostics([]);
     }
 
     private async requestCodeActions(
@@ -669,9 +724,32 @@ export class LanguageServerPlugin implements PluginValue {
                     });
                 });
 
-            if (!prepareResult || "defaultBehavior" in prepareResult) {
+            if (!prepareResult) {
                 showErrorMessage(view, "Cannot rename this symbol");
                 return;
+            }
+
+            let renameRange:
+                | LSP.Range
+                | { range: LSP.Range; placeholder: string };
+            if ("defaultBehavior" in prepareResult) {
+                // defaultBehavior: true means rename IS possible, using the
+                // client's default (word-at-cursor) range
+                if (!prepareResult.defaultBehavior) {
+                    showErrorMessage(view, "Cannot rename this symbol");
+                    return;
+                }
+                const fallback = this.prepareRenameFallback(view, {
+                    line,
+                    character,
+                });
+                if (!fallback) {
+                    showErrorMessage(view, "Cannot rename this symbol");
+                    return;
+                }
+                renameRange = fallback;
+            } else {
+                renameRange = prepareResult;
             }
 
             // Create popup input
@@ -687,7 +765,7 @@ export class LanguageServerPlugin implements PluginValue {
 
             // Get current word as default value
             const range =
-                "range" in prepareResult ? prepareResult.range : prepareResult;
+                "range" in renameRange ? renameRange.range : renameRange;
             const from = posToOffset(view.state.doc, range.start);
             if (from == null) {
                 return;
@@ -888,6 +966,10 @@ export class LanguageServerPlugin implements PluginValue {
             triggerCharacter,
         );
 
+        if (this.destroyed) {
+            return;
+        }
+
         // Dispatch the tooltip (or null to clear) via StateEffect
         view.dispatch({
             effects: setSignatureHelpTooltip.of(tooltip),
@@ -934,17 +1016,34 @@ export class LanguageServerPlugin implements PluginValue {
         const paramLabel = parameters[activeParameterIndex].label;
 
         if (typeof paramLabel === "string") {
-            // Simple string replacement
-            if (this.allowHTMLContent) {
-                signatureElement.innerHTML = signatureText.replace(
-                    paramLabel,
-                    `<strong class="cm-signature-active-param">${paramLabel}</strong>`,
+            // Find the parameter within the parameter list (after the opening
+            // paren) so a label like "s" does not match inside the function
+            // name, and highlight it without injecting the label as HTML.
+            // When several parameters share the same label text, walk past the
+            // earlier parameters so the active occurrence is the one chosen.
+            let searchFrom = signatureText.indexOf("(") + 1;
+            for (let i = 0; i < activeParameterIndex; i++) {
+                const previousLabel = parameters[i]?.label;
+                if (typeof previousLabel === "string") {
+                    const previousIndex = signatureText.indexOf(
+                        previousLabel,
+                        searchFrom,
+                    );
+                    if (previousIndex !== -1) {
+                        searchFrom = previousIndex + previousLabel.length;
+                    }
+                }
+            }
+            const paramIndex = signatureText.indexOf(paramLabel, searchFrom);
+            if (paramIndex !== -1) {
+                this.applyRangeHighlighting(
+                    signatureElement,
+                    signatureText,
+                    paramIndex,
+                    paramIndex + paramLabel.length,
                 );
             } else {
-                signatureElement.textContent = signatureText.replace(
-                    paramLabel,
-                    `«${paramLabel}»`,
-                );
+                signatureElement.textContent = signatureText;
             }
         } else if (Array.isArray(paramLabel) && paramLabel.length === 2) {
             // Handle array format [startIndex, endIndex]
@@ -1001,16 +1100,10 @@ export class LanguageServerPlugin implements PluginValue {
         docsElement.classList.add("cm-signature-docs");
         docsElement.style.cssText = "margin-top: 4px; color: #666;";
 
-        const formattedContent = formatContents(
-            documentation,
-            this.markdownRenderer,
-        );
-
-        if (this.allowHTMLContent) {
-            docsElement.innerHTML = formattedContent;
-        } else {
-            docsElement.textContent = formattedContent;
-        }
+        renderDocumentation(docsElement, documentation, {
+            allowHTMLContent: this.allowHTMLContent,
+            markdownRenderer: this.markdownRenderer,
+        });
 
         return docsElement;
     }
@@ -1026,16 +1119,10 @@ export class LanguageServerPlugin implements PluginValue {
         paramDocsElement.style.cssText =
             "margin-top: 4px; font-style: italic; border-top: 1px solid #eee; padding-top: 4px;";
 
-        const formattedContent = formatContents(
-            documentation,
-            this.markdownRenderer,
-        );
-
-        if (this.allowHTMLContent) {
-            paramDocsElement.innerHTML = formattedContent;
-        } else {
-            paramDocsElement.textContent = formattedContent;
-        }
+        renderDocumentation(paramDocsElement, documentation, {
+            allowHTMLContent: this.allowHTMLContent,
+            markdownRenderer: this.markdownRenderer,
+        });
 
         return paramDocsElement;
     }
@@ -1047,7 +1134,7 @@ export class LanguageServerPlugin implements PluginValue {
     private prepareRenameFallback(
         view: EditorView,
         { line, character }: { line: number; character: number },
-    ): LSP.PrepareRenameResult | null {
+    ): { range: LSP.Range; placeholder: string } | null {
         const doc = view.state.doc;
         const lineText = doc.line(line + 1).text;
         const wordRegex = /\w+/g;
@@ -1085,6 +1172,30 @@ export class LanguageServerPlugin implements PluginValue {
             },
             placeholder: lineText.slice(start, end),
         };
+    }
+
+    /**
+     * Applies a set of LSP text edits to the view in a single transaction.
+     * Edits with ranges that do not resolve in the current document are
+     * skipped.
+     * @returns True if any change was applied
+     */
+    private applyEdits(view: EditorView, edits: readonly LSP.TextEdit[]) {
+        const doc = view.state.doc;
+        const changes: { from: number; to: number; insert: string }[] = [];
+        for (const edit of edits) {
+            const from = posToOffset(doc, edit.range.start);
+            const to = posToOffset(doc, edit.range.end);
+            if (from == null || to == null || from > to) {
+                continue;
+            }
+            changes.push({ from, to, insert: edit.newText });
+        }
+        if (changes.length === 0) {
+            return false;
+        }
+        view.dispatch(view.state.update({ changes }));
+        return true;
     }
 
     /**
@@ -1128,23 +1239,7 @@ export class LanguageServerPlugin implements PluginValue {
                         continue;
                     }
 
-                    // Sort edits in reverse order to avoid position shifts
-                    const sortedEdits = docChange.edits.sort((a, b) => {
-                        const posA = posToOffset(view.state.doc, a.range.start);
-                        const posB = posToOffset(view.state.doc, b.range.start);
-                        return (posB ?? 0) - (posA ?? 0);
-                    });
-
-                    // Create a single transaction with all changes
-                    const changes = sortedEdits.map((edit) => ({
-                        from:
-                            posToOffset(view.state.doc, edit.range.start) ?? 0,
-                        to: posToOffset(view.state.doc, edit.range.end) ?? 0,
-                        insert: edit.newText,
-                    }));
-
-                    view.dispatch(view.state.update({ changes }));
-                    return true;
+                    return this.applyEdits(view, docChange.edits);
                 }
 
                 // This is a CreateFile, RenameFile, or DeleteFile operation
@@ -1154,38 +1249,19 @@ export class LanguageServerPlugin implements PluginValue {
                 );
                 return false;
             }
+            return false;
         }
+
         // Fall back to changes if documentChanges is not available
-        else if (Object.keys(changesMap).length > 0) {
-            // Apply all changes
-            for (const [uri, changes] of Object.entries(changesMap)) {
-                if (uri !== this.documentUri) {
-                    showErrorMessage(
-                        view,
-                        "Multi-file rename not supported yet",
-                    );
-                    continue;
-                }
-
-                // Sort changes in reverse order to avoid position shifts
-                const sortedChanges = changes.sort((a, b) => {
-                    const posA = posToOffset(view.state.doc, a.range.start);
-                    const posB = posToOffset(view.state.doc, b.range.start);
-                    return (posB ?? 0) - (posA ?? 0);
-                });
-
-                // Create a single transaction with all changes
-                const changeSpecs = sortedChanges.map((change) => ({
-                    from: posToOffset(view.state.doc, change.range.start) ?? 0,
-                    to: posToOffset(view.state.doc, change.range.end) ?? 0,
-                    insert: change.newText,
-                }));
-
-                view.dispatch(view.state.update({ changes: changeSpecs }));
+        let applied = false;
+        for (const [uri, changes] of Object.entries(changesMap)) {
+            if (uri !== this.documentUri) {
+                showErrorMessage(view, "Multi-file rename not supported yet");
+                continue;
             }
+            applied = this.applyEdits(view, changes) || applied;
         }
-
-        return false;
+        return applied;
     }
 }
 
@@ -1201,7 +1277,6 @@ export function languageServer(options: LanguageServerWebsocketOptions) {
 }
 
 export function languageServerWithClient(options: LanguageServerOptions) {
-    let plugin: LanguageServerPlugin | null = null;
     const shortcuts = {
         rename: "F2",
         goToDefinition: "F12",
@@ -1228,10 +1303,11 @@ export function languageServerWithClient(options: LanguageServerOptions) {
         ...options,
     };
 
-    // Create base extensions array
-    const extensions: Extension[] = [
-        ViewPlugin.define((view) => {
-            plugin = new LanguageServerPlugin({
+    // Each editor view gets its own plugin instance; look it up through the
+    // view so that several views sharing these extensions do not interfere
+    const lspViewPlugin = ViewPlugin.define(
+        (view) =>
+            new LanguageServerPlugin({
                 client: lsClient,
                 documentUri:
                     options.documentUri ?? view.state.facet(documentUri),
@@ -1243,10 +1319,12 @@ export function languageServerWithClient(options: LanguageServerOptions) {
                 useSnippetOnCompletion: options.useSnippetOnCompletion,
                 onGoToDefinition: options.onGoToDefinition,
                 markdownRenderer: options.markdownRenderer,
-            });
-            return plugin;
-        }),
-    ];
+            }),
+    );
+    const getPlugin = (view: EditorView) => view.plugin(lspViewPlugin);
+
+    // Create base extensions array
+    const extensions: Extension[] = [lspViewPlugin];
 
     // Add shortcuts
     extensions.push(
@@ -1254,6 +1332,7 @@ export function languageServerWithClient(options: LanguageServerOptions) {
             {
                 key: shortcuts.signatureHelp,
                 run: (view) => {
+                    const plugin = getPlugin(view);
                     if (!(plugin && featuresOptions.signatureHelpEnabled))
                         return false;
 
@@ -1265,6 +1344,7 @@ export function languageServerWithClient(options: LanguageServerOptions) {
             {
                 key: shortcuts.rename,
                 run: (view) => {
+                    const plugin = getPlugin(view);
                     if (!(plugin && featuresOptions.renameEnabled))
                         return false;
 
@@ -1279,6 +1359,7 @@ export function languageServerWithClient(options: LanguageServerOptions) {
             {
                 key: shortcuts.goToDefinition,
                 run: (view) => {
+                    const plugin = getPlugin(view);
                     if (!(plugin && featuresOptions.definitionEnabled))
                         return false;
 
@@ -1304,6 +1385,7 @@ export function languageServerWithClient(options: LanguageServerOptions) {
     if (featuresOptions.hoverEnabled) {
         extensions.push(
             hoverTooltip((view, pos) => {
+                const plugin = getPlugin(view);
                 if (plugin == null) {
                     return null;
                 }
@@ -1367,7 +1449,12 @@ export function languageServerWithClient(options: LanguageServerOptions) {
         // and dismiss the signature help tooltip.
         extensions.push(
             EditorView.updateListener.of((update) => {
-                if (!(plugin && featuresOptions.signatureActivateOnTyping))
+                if (
+                    !(
+                        getPlugin(update.view) &&
+                        featuresOptions.signatureActivateOnTyping
+                    )
+                )
                     return;
 
                 const tooltip = update.state.field(signatureHelpTooltipField);
@@ -1381,13 +1468,18 @@ export function languageServerWithClient(options: LanguageServerOptions) {
 
                 // If not inside any parentheses, dismiss
                 if (!isCursorInsideFunctionCall(update.state.doc, cursorPos)) {
-                    hideSignatureHelpTooltip(update.view);
+                    // Dispatching is not allowed while an update is in
+                    // progress, so defer the dismissal
+                    queueMicrotask(() => {
+                        hideSignatureHelpTooltip(update.view);
+                    });
                 }
             }),
         );
 
         extensions.push(
             EditorView.updateListener.of(async (update) => {
+                const plugin = getPlugin(update.view);
                 if (!(plugin && update.docChanged)) return;
 
                 if (
@@ -1454,6 +1546,9 @@ export function languageServerWithClient(options: LanguageServerOptions) {
                      * @returns A CompletionResult or null if no completions are available
                      */
                     async (context) => {
+                        const plugin = context.view
+                            ? getPlugin(context.view)
+                            : null;
                         // Don't proceed if plugin isn't initialized
                         if (plugin == null) {
                             return null;
@@ -1500,6 +1595,7 @@ export function languageServerWithClient(options: LanguageServerOptions) {
                         x: event.clientX,
                         y: event.clientY,
                     });
+                    const plugin = getPlugin(view);
                     if (pos && plugin) {
                         plugin
                             .requestDefinition(

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -278,16 +278,25 @@ describe("posToOffset", () => {
         expect(posToOffset(doc, { line: 2, character: 0 })).toBe(5); // Line far beyond document but character 0 returns doc.length
     });
 
-    it("should return undefined for character beyond line length", () => {
+    it("should clamp character beyond line length to the end of the line", () => {
+        // Per LSP spec: "If the character value is greater than the line
+        // length it defaults back to the line length."
         const doc = Text.of(["hello"]);
-        expect(posToOffset(doc, { line: 0, character: 10 })).toBeUndefined();
+        expect(posToOffset(doc, { line: 0, character: 10 })).toBe(5);
+    });
+
+    it("should not spill into the next line when character overflows", () => {
+        const doc = Text.of(["ab", "cdef"]);
+        // Offset 5 would be inside line 2 ("cdef"); it must clamp to 2 (end of line 1)
+        expect(posToOffset(doc, { line: 0, character: 5 })).toBe(2);
+        expect(posToOffset(doc, { line: 1, character: 100 })).toBe(7);
     });
 
     it("should handle empty document", () => {
         const doc = Text.of([""]);
         expect(posToOffset(doc, { line: 0, character: 0 })).toBe(0);
         expect(posToOffset(doc, { line: 1, character: 0 })).toBe(0);
-        expect(posToOffset(doc, { line: 0, character: 1 })).toBeUndefined();
+        expect(posToOffset(doc, { line: 0, character: 1 })).toBe(0);
     });
 
     it("should handle empty lines", () => {
@@ -359,9 +368,13 @@ describe("posToOffsetOrZero", () => {
         expect(posToOffsetOrZero(doc, { line: 0, character: 5 })).toBe(5);
     });
 
-    it("should return zero when position is invalid", () => {
+    it("should clamp character overflow to line end", () => {
         const doc = Text.of(["hello"]);
-        expect(posToOffsetOrZero(doc, { line: 0, character: 10 })).toBe(0);
+        expect(posToOffsetOrZero(doc, { line: 0, character: 10 })).toBe(5);
+    });
+
+    it("should return zero when the line is beyond the document", () => {
+        const doc = Text.of(["hello"]);
         expect(posToOffsetOrZero(doc, { line: 1, character: 5 })).toBe(0);
     });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,11 +15,10 @@ export function posToOffset(
         }
         return;
     }
-    const offset = doc.line(pos.line + 1).from + pos.character;
-    if (offset > doc.length) {
-        return;
-    }
-    return offset;
+    const line = doc.line(pos.line + 1);
+    // Per LSP spec, a character beyond the line length defaults back to the
+    // line length, so clamp instead of spilling into the next line
+    return Math.min(line.from + pos.character, line.to);
 }
 
 export function posToOffsetOrZero(
@@ -84,7 +83,68 @@ export function formatContents(
     if (typeof contents === "string") {
         return contents;
     }
+    if (isLSPMarkedStringObject(contents)) {
+        // Legacy MarkedString form: render as a fenced code block
+        return markdownRenderer(
+            `\`\`\`${contents.language}\n${contents.value}\n\`\`\``,
+        );
+    }
     return "";
+}
+
+/**
+ * Extract the raw text of documentation contents, without rendering
+ * markdown to HTML. Used when HTML content is not allowed.
+ */
+export function formatPlainTextContents(
+    contents:
+        | LSP.MarkupContent
+        | LSP.MarkedString
+        | LSP.MarkedString[]
+        | undefined,
+): string {
+    if (!contents) {
+        return "";
+    }
+    if (isLSPMarkupContent(contents)) {
+        return contents.value;
+    }
+    if (Array.isArray(contents)) {
+        return contents
+            .map((c) => formatPlainTextContents(c))
+            .filter(Boolean)
+            .join("\n\n");
+    }
+    if (typeof contents === "string") {
+        return contents;
+    }
+    if (isLSPMarkedStringObject(contents)) {
+        return contents.value;
+    }
+    return "";
+}
+
+/**
+ * Render documentation contents into an element, as HTML when allowed and
+ * as plain text otherwise (never showing HTML markup as literal text).
+ */
+export function renderDocumentation(
+    element: HTMLElement,
+    contents:
+        | LSP.MarkupContent
+        | LSP.MarkedString
+        | LSP.MarkedString[]
+        | undefined,
+    options: {
+        allowHTMLContent: boolean;
+        markdownRenderer?: (markdown: string) => string;
+    },
+): void {
+    if (options.allowHTMLContent) {
+        element.innerHTML = formatContents(contents, options.markdownRenderer);
+    } else {
+        element.textContent = formatPlainTextContents(contents);
+    }
 }
 
 /**
@@ -159,6 +219,17 @@ export function isLSPMarkupContent(
     contents: LSP.MarkupContent | LSP.MarkedString | LSP.MarkedString[],
 ): contents is LSP.MarkupContent {
     return (contents as LSP.MarkupContent).kind !== undefined;
+}
+
+function isLSPMarkedStringObject(
+    contents: LSP.MarkupContent | LSP.MarkedString | LSP.MarkedString[],
+): contents is { language: string; value: string } {
+    return (
+        typeof contents === "object" &&
+        contents !== null &&
+        "language" in contents &&
+        "value" in contents
+    );
 }
 
 export function showErrorMessage(view: EditorView, message: string) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     test: {
         globals: true,
         environment: "jsdom",
+        setupFiles: ["./src/__tests__/setup.ts"],
         coverage: {
             enabled: true,
             reporter: ["text", "html", "json-summary", "json"],
@@ -15,6 +16,7 @@ export default defineConfig({
                 "demo/**",
                 "**/*.d.ts",
                 "**/*.test.ts",
+                "src/__tests__/setup.ts",
                 "vite.config.ts",
             ],
             include: ["src/**/*.ts"],


### PR DESCRIPTION
Document sync & lifecycle:
- didOpen reads the document at send time so edits during server init are
  not lost; honor server-declared textDocumentSync kind; send didClose on
  destroy and skip dispatches after destroy
- client close() resets ready, clears listeners, detaches the WS handler;
  failed initialize no longer leaks an unhandled rejection; server->client
  requests with JSON-RPC id:0 get responses; non-JSON frames are ignored;
  one throwing notification listener no longer starves the others

Diagnostics:
- resolve ranges against a snapshot, drop ranges that no longer fit instead
  of collapsing to offset 0, ignore out-of-order stale versions, and merge
  with (rather than wipe) diagnostics from other sources
- renderMessage respects allowHTMLContent

Completion:
- unknown CompletionItemKind no longer crashes the list
- snippet-format textEdits expand as snippets (or are stripped when snippet
  UX is off) instead of inserting literal ${1:arg}
- additionalTextEdits resolve against the pre-completion doc and apply with
  the main edit in one transaction; convertSnippet handles escapes; prefix
  boosting compares filterText/label, not opaque sortText

Rename / config / utils / signature help:
- prepareRename {defaultBehavior:true} proceeds; changes-map branch reports
  success; shared applyEdits helper
- facet combine takes highest-precedence value (values[0])
- posToOffset clamps character overflow per spec; formatContents renders
  legacy MarkedString objects
- active signature parameter located after '(' and highlighted via DOM nodes
- per-view plugin lookup so shared extensions don't cross-wire two editors

Consolidate 6 copy-pasted render blocks into renderDocumentation.
