### PR TITLE
demo: in-browser Python (Ruff) and TypeScript worker demos

### DIFF
--- a/demo/demos.ts
+++ b/demo/demos.ts
@@ -1,0 +1,16 @@
+import { mountMockDemo } from "./mock/mockDemo";
+import { mountPythonDemo } from "./python/pythonDemo";
+import { mountTypeScriptDemo } from "./typescript/tsDemo";
+
+export interface Demo {
+    id: string;
+    label: string;
+    /** Build the demo inside `container`; returns a dispose callback. */
+    mount: (container: HTMLElement) => () => void;
+}
+
+export const DEMOS: Demo[] = [
+    { id: "mock", label: "Mock · in-memory", mount: mountMockDemo },
+    { id: "python", label: "Python · Ruff", mount: mountPythonDemo },
+    { id: "typescript", label: "TypeScript · vfs", mount: mountTypeScriptDemo },
+];

--- a/demo/index.html
+++ b/demo/index.html
@@ -9,12 +9,46 @@
                 margin: 0;
                 padding: 20px;
                 font-family: system-ui, -apple-system, sans-serif;
+                max-width: 900px;
             }
-            #editor {
-                height: 400px;
+            #tabs {
+                display: flex;
+                gap: 4px;
+                margin-bottom: 16px;
+                border-bottom: 1px solid #ddd;
+            }
+            .tab {
+                padding: 8px 16px;
+                border: none;
+                border-bottom: 2px solid transparent;
+                background: transparent;
+                color: #444;
+                cursor: pointer;
+                font-size: 14px;
+            }
+            .tab:hover {
+                background: #f5f5f5;
+            }
+            .tab.active {
+                color: #4a90e2;
+                border-bottom-color: #4a90e2;
+                font-weight: 600;
+            }
+            .cm-editor {
+                height: 420px;
                 border: 1px solid #ddd;
                 border-radius: 4px;
-                margin-bottom: 20px;
+            }
+            .demo-hint {
+                margin: 0 0 12px;
+                color: #555;
+                font-size: 13px;
+                line-height: 1.5;
+            }
+            .demo-hint code {
+                background: #f0f0f0;
+                padding: 1px 4px;
+                border-radius: 3px;
             }
             .cm-rename-popup {
                 background: white;
@@ -29,7 +63,7 @@
                 font-family: inherit;
             }
             .demo-controls {
-                margin-bottom: 20px;
+                margin-bottom: 16px;
             }
             .demo-controls button {
                 margin-right: 8px;
@@ -47,12 +81,13 @@
     </head>
     <body>
         <h1>CodeMirror LSP Demo</h1>
-        <div class="demo-controls">
-            <button id="addError">Add Error</button>
-            <button id="addWarning">Add Warning</button>
-            <button id="clearDiagnostics">Clear Diagnostics</button>
-        </div>
-        <div id="editor"></div>
+        <p>
+            Three language servers, all running in the browser. Switch tabs to
+            try diagnostics, completion, hover, go-to-definition, signature
+            help, rename, and code actions.
+        </p>
+        <div id="tabs"></div>
+        <div id="demo-root"></div>
         <div>
             <h3>Keyboard Shortcuts:</h3>
             <ul>

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -1,243 +1,40 @@
-import { javascript } from "@codemirror/lang-javascript";
-import { lintGutter } from "@codemirror/lint";
-import { EditorState } from "@codemirror/state";
-import { EditorView, tooltips } from "@codemirror/view";
-import type {
-    IJSONRPCData,
-    IJSONRPCNotification,
-    IJSONRPCResponse,
-    JSONRPCRequestData,
-} from "@open-rpc/client-js/build/Request";
-import { Transport } from "@open-rpc/client-js/build/transports/Transport";
-import { basicSetup } from "codemirror";
-import { LanguageServerClient, languageServerWithClient } from "../src";
-import { MockLSPServer } from "./mockLSP";
+import { DEMOS } from "./demos";
 
-// Create mock WebSocket transport
-class MockWebSocket {
-    private server: MockLSPServer;
-    private onMessageCallback?: (data: IJSONRPCResponse) => void;
-    private onNotificationCallback?: (data: IJSONRPCNotification) => void;
-    private onErrorCallback?: (data: IJSONRPCNotification) => void;
+const tabs = document.querySelector<HTMLElement>("#tabs");
+const root = document.querySelector<HTMLElement>("#demo-root");
 
-    constructor(server: MockLSPServer) {
-        this.server = server;
-        // Set up diagnostic notifications
-        this.server.setOnDiagnostics((params) => {
-            if (this.onNotificationCallback) {
-                this.onNotificationCallback({
-                    jsonrpc: "2.0",
-                    method: "textDocument/publishDiagnostics",
-                    params,
-                });
-            }
-        });
+if (tabs && root) {
+    let dispose: (() => void) | null = null;
+    const buttons: HTMLButtonElement[] = [];
+
+    const activate = (index: number) => {
+        const demo = DEMOS[index];
+        if (!demo) {
+            return;
+        }
+        // Tear down the previous demo (destroys its editor + terminates its
+        // worker) before mounting the next one.
+        dispose?.();
+        dispose = null;
+        root.replaceChildren();
+
+        for (const [i, button] of buttons.entries()) {
+            button.classList.toggle("active", i === index);
+        }
+
+        const container = document.createElement("div");
+        root.appendChild(container);
+        dispose = demo.mount(container);
+    };
+
+    for (const [index, demo] of DEMOS.entries()) {
+        const button = document.createElement("button");
+        button.textContent = demo.label;
+        button.className = "tab";
+        button.addEventListener("click", () => activate(index));
+        buttons.push(button);
+        tabs.appendChild(button);
     }
 
-    send(data: IJSONRPCData) {
-        const request = data;
-        const { method, id: _id, params } = request.request;
-        // biome-ignore lint/suspicious/noExplicitAny: <explanation>
-        const anyParams = params as any;
-        const id = _id ?? "_";
-
-        // Handle LSP messages
-        // biome-ignore lint/suspicious/noConsoleLog: <explanation>
-        console.log("method", method);
-        if (method === "initialize") {
-            return this.respond(id, this.server.initialize());
-        }
-        if (method === "textDocument/didOpen") {
-            return this.server.didOpenTextDocument(anyParams);
-        }
-        if (method === "textDocument/didChange") {
-            return this.server.didChangeTextDocument(anyParams);
-        }
-        if (method === "textDocument/completion") {
-            return this.server
-                .completion(anyParams)
-                .then((result) => this.respond(id, result));
-        }
-        if (method === "completionItem/resolve") {
-            return this.server
-                .completionResolve(anyParams)
-                .then((result) => this.respond(id, result));
-        }
-        if (method === "textDocument/hover") {
-            return this.server
-                .hover(anyParams)
-                .then((result) => this.respond(id, result));
-        }
-        if (method === "textDocument/definition") {
-            return this.server
-                .definition(anyParams)
-                .then((result) => this.respond(id, result));
-        }
-        if (method === "textDocument/prepareRename") {
-            return this.server
-                .prepareRename(anyParams)
-                .then((result) => this.respond(id, result));
-        }
-        if (method === "textDocument/rename") {
-            return this.server
-                .rename(anyParams)
-                .then((result) => this.respond(id, result));
-        }
-        if (method === "textDocument/codeAction") {
-            return this.server
-                .codeAction(anyParams)
-                .then((result) => this.respond(id, result));
-        }
-        /**
-         * Handle signature help requests from the editor
-         * Returns parameter information when typing function calls
-         */
-        if (method === "textDocument/signatureHelp") {
-            return this.server
-                .signatureHelp(anyParams)
-                .then((result) => this.respond(id, result));
-        }
-    }
-
-    addEventListener(
-        event: string,
-        callback: (data: IJSONRPCResponse | IJSONRPCNotification) => void,
-    ) {
-        if (event === "notification") {
-            this.onNotificationCallback = callback;
-        }
-        if (event === "error") {
-            this.onErrorCallback = callback;
-        }
-        if (event === "message") {
-            this.onMessageCallback = callback;
-        }
-    }
-
-    private respond(id: string | number, result: IJSONRPCResponse["result"]) {
-        const body: IJSONRPCResponse = {
-            jsonrpc: "2.0",
-            id,
-            result,
-        };
-        if (this.onMessageCallback) {
-            this.onMessageCallback(body);
-        }
-        return body;
-    }
+    activate(0);
 }
-
-// Create mock transport
-const mockServer = new MockLSPServer();
-const mockSocket = new MockWebSocket(mockServer);
-class MockTransport extends Transport {
-    private callbacks: Map<
-        string,
-        ((data: IJSONRPCResponse | IJSONRPCNotification) => void)[]
-    > = new Map();
-
-    connect() {
-        return Promise.resolve();
-    }
-
-    send(data: IJSONRPCData) {
-        return mockSocket.send(data);
-    }
-
-    subscribe(
-        event: string,
-        callback: (data: IJSONRPCResponse | IJSONRPCNotification) => void,
-    ) {
-        const callbacks = this.callbacks.get(event) || [];
-        callbacks.push(callback);
-        this.callbacks.set(event, callbacks);
-        mockSocket.addEventListener(event, (data) => {
-            if ("method" in data) {
-                // This is a notification
-                for (const cb of callbacks) {
-                    cb(data);
-                }
-            } else {
-                // This is a response
-                for (const cb of callbacks) {
-                    cb(data);
-                }
-            }
-        });
-    }
-
-    async sendData(data: JSONRPCRequestData) {
-        const body = await mockSocket.send(data as IJSONRPCData);
-        if (body) {
-            return "result" in body ? body.result : undefined;
-        }
-        return body;
-    }
-
-    close() {
-        this.callbacks.clear();
-    }
-}
-
-const mockTransport = new MockTransport();
-
-// Set up the editor
-const doc = `// CodeMirror LSP Demo
-// Try these features:
-// 1. Hover over text
-// 2. Press F2 to rename
-// 3. Ctrl/Cmd+Click for definition
-// 4. Type 'console.' for completion
-
-function example() {
-    console.log("Hello, World!");
-}
-`;
-
-const state = EditorState.create({
-    doc,
-    extensions: [
-        basicSetup,
-        javascript(),
-        tooltips({
-            position: "absolute",
-        }),
-        lintGutter(),
-        languageServerWithClient({
-            client: new LanguageServerClient({
-                rootUri: "file:///",
-                workspaceFolders: [],
-                transport: mockTransport,
-            }),
-            allowHTMLContent: true,
-            documentUri: "file:///example.ts",
-            languageId: "typescript",
-            onGoToDefinition: (result) => {
-                // biome-ignore lint/suspicious/noConsoleLog: <explanation>
-                console.log("Go to definition", result);
-            },
-        }),
-    ],
-});
-
-const view = new EditorView({
-    state,
-    parent: document.querySelector("#editor") as Element,
-});
-
-// Set up diagnostic buttons
-document.querySelector("#addError")?.addEventListener("click", () => {
-    const line =
-        view.state.doc.lineAt(view.state.selection.main.head).number - 1;
-    mockServer.addErrorDiagnostic("file:///example.ts", line);
-});
-
-document.querySelector("#addWarning")?.addEventListener("click", () => {
-    const line =
-        view.state.doc.lineAt(view.state.selection.main.head).number - 1;
-    mockServer.addWarningDiagnostic("file:///example.ts", line);
-});
-
-document.querySelector("#clearDiagnostics")?.addEventListener("click", () => {
-    mockServer.clearDiagnostics("file:///example.ts");
-});

--- a/demo/mock/mockDemo.ts
+++ b/demo/mock/mockDemo.ts
@@ -1,0 +1,249 @@
+import { javascript } from "@codemirror/lang-javascript";
+import { lintGutter } from "@codemirror/lint";
+import { EditorState } from "@codemirror/state";
+import { EditorView, tooltips } from "@codemirror/view";
+import type {
+    IJSONRPCData,
+    IJSONRPCNotification,
+    IJSONRPCResponse,
+    JSONRPCRequestData,
+} from "@open-rpc/client-js/build/Request";
+import { Transport } from "@open-rpc/client-js/build/transports/Transport";
+import { basicSetup } from "codemirror";
+import { LanguageServerClient, languageServerWithClient } from "../../src";
+import { MockLSPServer } from "../mockLSP";
+
+// Mock WebSocket-like bridge to the in-memory LSP server.
+class MockWebSocket {
+    private server: MockLSPServer;
+    private onMessageCallback?: (data: IJSONRPCResponse) => void;
+    private onNotificationCallback?: (data: IJSONRPCNotification) => void;
+    private onErrorCallback?: (data: IJSONRPCNotification) => void;
+
+    constructor(server: MockLSPServer) {
+        this.server = server;
+        this.server.setOnDiagnostics((params) => {
+            if (this.onNotificationCallback) {
+                this.onNotificationCallback({
+                    jsonrpc: "2.0",
+                    method: "textDocument/publishDiagnostics",
+                    params,
+                });
+            }
+        });
+    }
+
+    send(data: IJSONRPCData) {
+        const request = data;
+        const { method, id: _id, params } = request.request;
+        // biome-ignore lint/suspicious/noExplicitAny: RPC params are dynamic.
+        const anyParams = params as any;
+        const id = _id ?? "_";
+
+        if (method === "initialize") {
+            return this.respond(id, this.server.initialize());
+        }
+        if (method === "textDocument/didOpen") {
+            return this.server.didOpenTextDocument(anyParams);
+        }
+        if (method === "textDocument/didChange") {
+            return this.server.didChangeTextDocument(anyParams);
+        }
+        if (method === "textDocument/completion") {
+            return this.server
+                .completion(anyParams)
+                .then((result) => this.respond(id, result));
+        }
+        if (method === "completionItem/resolve") {
+            return this.server
+                .completionResolve(anyParams)
+                .then((result) => this.respond(id, result));
+        }
+        if (method === "textDocument/hover") {
+            return this.server
+                .hover(anyParams)
+                .then((result) => this.respond(id, result));
+        }
+        if (method === "textDocument/definition") {
+            return this.server
+                .definition(anyParams)
+                .then((result) => this.respond(id, result));
+        }
+        if (method === "textDocument/prepareRename") {
+            return this.server
+                .prepareRename(anyParams)
+                .then((result) => this.respond(id, result));
+        }
+        if (method === "textDocument/rename") {
+            return this.server
+                .rename(anyParams)
+                .then((result) => this.respond(id, result));
+        }
+        if (method === "textDocument/codeAction") {
+            return this.server
+                .codeAction(anyParams)
+                .then((result) => this.respond(id, result));
+        }
+        if (method === "textDocument/signatureHelp") {
+            return this.server
+                .signatureHelp(anyParams)
+                .then((result) => this.respond(id, result));
+        }
+    }
+
+    addEventListener(
+        event: string,
+        callback: (data: IJSONRPCResponse | IJSONRPCNotification) => void,
+    ) {
+        if (event === "notification") {
+            this.onNotificationCallback = callback;
+        }
+        if (event === "error") {
+            this.onErrorCallback = callback;
+        }
+        if (event === "message") {
+            this.onMessageCallback = callback;
+        }
+    }
+
+    private respond(id: string | number, result: IJSONRPCResponse["result"]) {
+        const body: IJSONRPCResponse = {
+            jsonrpc: "2.0",
+            id,
+            result,
+        };
+        if (this.onMessageCallback) {
+            this.onMessageCallback(body);
+        }
+        return body;
+    }
+}
+
+class MockTransport extends Transport {
+    private callbacks: Map<
+        string,
+        ((data: IJSONRPCResponse | IJSONRPCNotification) => void)[]
+    > = new Map();
+
+    constructor(private socket: MockWebSocket) {
+        super();
+    }
+
+    connect() {
+        return Promise.resolve();
+    }
+
+    send(data: IJSONRPCData) {
+        return this.socket.send(data);
+    }
+
+    subscribe(
+        event: string,
+        callback: (data: IJSONRPCResponse | IJSONRPCNotification) => void,
+    ) {
+        const callbacks = this.callbacks.get(event) || [];
+        callbacks.push(callback);
+        this.callbacks.set(event, callbacks);
+        this.socket.addEventListener(event, (data) => {
+            for (const cb of callbacks) {
+                cb(data);
+            }
+        });
+    }
+
+    async sendData(data: JSONRPCRequestData) {
+        const body = await this.socket.send(data as IJSONRPCData);
+        if (body) {
+            return "result" in body ? body.result : undefined;
+        }
+        return body;
+    }
+
+    close() {
+        this.callbacks.clear();
+    }
+}
+
+const DOCUMENT_URI = "file:///example.ts";
+
+const SAMPLE = `// CodeMirror LSP Demo (in-memory mock server)
+// Try these features:
+// 1. Hover over text
+// 2. Press F2 to rename
+// 3. Ctrl/Cmd+Click for definition
+// 4. Type 'console.' for completion
+
+function example() {
+    console.log("Hello, World!");
+}
+`;
+
+/**
+ * Mounts the original demo: a hand-written in-memory mock LSP server with
+ * buttons to push synthetic diagnostics. Unchanged in behavior from the
+ * pre-tabs demo.
+ */
+export function mountMockDemo(container: HTMLElement): () => void {
+    const mockServer = new MockLSPServer();
+    const mockSocket = new MockWebSocket(mockServer);
+    const mockTransport = new MockTransport(mockSocket);
+
+    const controls = document.createElement("div");
+    controls.className = "demo-controls";
+    const addError = button("Add Error");
+    const addWarning = button("Add Warning");
+    const clear = button("Clear Diagnostics");
+    controls.append(addError, addWarning, clear);
+    container.appendChild(controls);
+
+    const client = new LanguageServerClient({
+        rootUri: "file:///",
+        workspaceFolders: [],
+        transport: mockTransport,
+    });
+
+    const view = new EditorView({
+        state: EditorState.create({
+            doc: SAMPLE,
+            extensions: [
+                basicSetup,
+                javascript(),
+                tooltips({ position: "absolute" }),
+                lintGutter(),
+                languageServerWithClient({
+                    client,
+                    allowHTMLContent: true,
+                    documentUri: DOCUMENT_URI,
+                    languageId: "typescript",
+                    onGoToDefinition: (result) => {
+                        console.debug("Go to definition", result);
+                    },
+                }),
+            ],
+        }),
+        parent: container,
+    });
+
+    const currentLine = () =>
+        view.state.doc.lineAt(view.state.selection.main.head).number - 1;
+    addError.addEventListener("click", () => {
+        mockServer.addErrorDiagnostic(DOCUMENT_URI, currentLine());
+    });
+    addWarning.addEventListener("click", () => {
+        mockServer.addWarningDiagnostic(DOCUMENT_URI, currentLine());
+    });
+    clear.addEventListener("click", () => {
+        mockServer.clearDiagnostics(DOCUMENT_URI);
+    });
+
+    return () => {
+        view.destroy();
+        client.close();
+    };
+}
+
+function button(label: string): HTMLButtonElement {
+    const element = document.createElement("button");
+    element.textContent = label;
+    return element;
+}

--- a/demo/python/pythonDemo.ts
+++ b/demo/python/pythonDemo.ts
@@ -1,0 +1,66 @@
+import { python } from "@codemirror/lang-python";
+import { lintGutter } from "@codemirror/lint";
+import { EditorState } from "@codemirror/state";
+import { EditorView, tooltips } from "@codemirror/view";
+import { basicSetup } from "codemirror";
+import { languageServerWithClient } from "../../src";
+import { createWorkerClient } from "../shared/workerTransport";
+
+const DOCUMENT_URI = "file:///main.py";
+
+const SAMPLE = `import os
+import sys
+
+
+def greet(name):
+    message = "Hello, " + name
+    print( message )
+
+
+greet("world")
+`;
+
+/**
+ * Mounts a Python editor backed by Ruff (WASM) running in a Web Worker.
+ * Exercises diagnostics, quick-fix / fix-all code actions, and formatting
+ * (the latter two surface as actions in each diagnostic's tooltip).
+ */
+export function mountPythonDemo(container: HTMLElement): () => void {
+    const hint = document.createElement("p");
+    hint.className = "demo-hint";
+    hint.innerHTML =
+        "Backed by <code>@astral-sh/ruff-wasm-web</code> in a Web Worker. " +
+        "Hover a diagnostic to see quick-fix, <em>Fix all</em>, and " +
+        "<em>Format document</em> actions.";
+    container.appendChild(hint);
+
+    const worker = new Worker(new URL("./worker.ts", import.meta.url), {
+        type: "module",
+    });
+    const client = createWorkerClient(worker, { rootUri: "file:///" });
+
+    const view = new EditorView({
+        state: EditorState.create({
+            doc: SAMPLE,
+            extensions: [
+                basicSetup,
+                python(),
+                tooltips({ position: "absolute" }),
+                lintGutter(),
+                languageServerWithClient({
+                    client,
+                    documentUri: DOCUMENT_URI,
+                    languageId: "python",
+                    allowHTMLContent: true,
+                    sendIncrementalChanges: false,
+                }),
+            ],
+        }),
+        parent: container,
+    });
+
+    return () => {
+        view.destroy();
+        client.close();
+    };
+}

--- a/demo/python/ruffServer.ts
+++ b/demo/python/ruffServer.ts
@@ -1,0 +1,176 @@
+import type {
+    Diagnostic as RuffDiagnostic,
+    Workspace,
+} from "@astral-sh/ruff-wasm-web";
+import type * as LSP from "vscode-languageserver-protocol";
+import {
+    DiagnosticSeverity,
+    TextDocumentSyncKind,
+} from "vscode-languageserver-protocol";
+
+type RuffFix = NonNullable<RuffDiagnostic["fix"]>;
+
+/**
+ * A tiny LSP server around Ruff's WASM `Workspace`. Ruff only lints and formats,
+ * so this advertises diagnostics + code actions (quick-fixes, fix-all, and a
+ * whole-document "Format" action) and nothing else. Positions coming out of Ruff
+ * are 1-based `{row, column}`; LSP is 0-based `{line, character}`.
+ */
+export class RuffServer {
+    private documents = new Map<string, string>();
+    // Cache the raw Ruff diagnostics per document so code actions can look up
+    // the fix that belongs to a given range without re-running the linter.
+    private diagnosticsCache = new Map<string, RuffDiagnostic[]>();
+
+    constructor(private workspace: Workspace) {}
+
+    initializeResult(): LSP.InitializeResult {
+        return {
+            capabilities: {
+                textDocumentSync: TextDocumentSyncKind.Full,
+                codeActionProvider: {
+                    codeActionKinds: ["quickfix", "source.fixAll", "source"],
+                },
+            },
+        };
+    }
+
+    /** Store the latest text, re-lint, and return diagnostics to publish. */
+    setDocument(uri: string, text: string): LSP.PublishDiagnosticsParams {
+        this.documents.set(uri, text);
+        const ruffDiagnostics = this.check(text);
+        this.diagnosticsCache.set(uri, ruffDiagnostics);
+        return {
+            uri,
+            diagnostics: ruffDiagnostics.map(toLspDiagnostic),
+        };
+    }
+
+    codeAction(params: LSP.CodeActionParams): LSP.CodeAction[] {
+        const uri = params.textDocument.uri;
+        const text = this.documents.get(uri) ?? "";
+        const cached = this.diagnosticsCache.get(uri) ?? [];
+        const actions: LSP.CodeAction[] = [];
+
+        // Quick-fix for the specific diagnostic the tooltip was opened on.
+        const target = cached.find(
+            (diagnostic) =>
+                diagnostic.fix != null &&
+                rangesOverlap(toRange(diagnostic), params.range),
+        );
+        if (target?.fix) {
+            actions.push({
+                title: target.fix.message || `Fix ${target.code ?? "issue"}`,
+                kind: "quickfix",
+                edit: { changes: { [uri]: fixToEdits(target.fix) } },
+            });
+        }
+
+        // Fix-all: aggregate every fixable diagnostic in the document.
+        const fixable = cached.filter((diagnostic) => diagnostic.fix != null);
+        if (fixable.length > 1) {
+            const edits = fixable.flatMap((diagnostic) =>
+                diagnostic.fix ? fixToEdits(diagnostic.fix) : [],
+            );
+            actions.push({
+                title: `Fix all auto-fixable (${fixable.length}) (Ruff)`,
+                kind: "source.fixAll",
+                edit: { changes: { [uri]: edits } },
+            });
+        }
+
+        // Format the whole document via Ruff's formatter.
+        actions.push({
+            title: "Format document (Ruff)",
+            kind: "source",
+            edit: {
+                changes: {
+                    [uri]: [wholeDocumentEdit(text, this.format(text))],
+                },
+            },
+        });
+
+        return actions;
+    }
+
+    private check(text: string): RuffDiagnostic[] {
+        try {
+            return this.workspace.check(text) as RuffDiagnostic[];
+        } catch (error) {
+            console.error("Ruff check failed", error);
+            return [];
+        }
+    }
+
+    private format(text: string): string {
+        try {
+            return this.workspace.format(text);
+        } catch (error) {
+            console.error("Ruff format failed", error);
+            return text;
+        }
+    }
+}
+
+function toLspDiagnostic(diagnostic: RuffDiagnostic): LSP.Diagnostic {
+    return {
+        range: toRange(diagnostic),
+        message: diagnostic.message,
+        code: diagnostic.code ?? undefined,
+        severity: toSeverity(diagnostic.code),
+        source: "ruff",
+    };
+}
+
+function toRange(diagnostic: RuffDiagnostic): LSP.Range {
+    return {
+        start: toPosition(diagnostic.start_location),
+        end: toPosition(diagnostic.end_location),
+    };
+}
+
+function toPosition(location: { row: number; column: number }): LSP.Position {
+    return { line: location.row - 1, character: location.column - 1 };
+}
+
+function toSeverity(code: string | null): LSP.DiagnosticSeverity {
+    // Ruff has no severity concept; treat syntax errors (E9xx / null code) as
+    // errors and every lint rule as a warning.
+    if (code == null || code.startsWith("E9")) {
+        return DiagnosticSeverity.Error;
+    }
+    return DiagnosticSeverity.Warning;
+}
+
+function fixToEdits(fix: RuffFix): LSP.TextEdit[] {
+    return fix.edits.map((edit) => ({
+        range: {
+            start: toPosition(edit.location),
+            end: toPosition(edit.end_location),
+        },
+        newText: edit.content ?? "",
+    }));
+}
+
+function wholeDocumentEdit(text: string, newText: string): LSP.TextEdit {
+    const lines = text.split("\n");
+    const lastLine = lines.length - 1;
+    return {
+        range: {
+            start: { line: 0, character: 0 },
+            end: { line: lastLine, character: lines[lastLine].length },
+        },
+        newText,
+    };
+}
+
+function rangesOverlap(a: LSP.Range, b: LSP.Range): boolean {
+    return !(isBefore(a.end, b.start) || isBefore(b.end, a.start));
+}
+
+function isBefore(a: LSP.Position, b: LSP.Position): boolean {
+    if (a.line !== b.line) {
+        return a.line < b.line;
+    }
+    return a.character < b.character;
+}

--- a/demo/python/worker.ts
+++ b/demo/python/worker.ts
@@ -1,0 +1,50 @@
+import init, { PositionEncoding, Workspace } from "@astral-sh/ruff-wasm-web";
+import type * as LSP from "vscode-languageserver-protocol";
+import { publishDiagnostics, serve } from "../shared/workerRpc";
+import { RuffServer } from "./ruffServer";
+
+const RUFF_CONFIG = {
+    "line-length": 88,
+    "indent-width": 4,
+    lint: {
+        select: ["E", "F", "W", "I"],
+    },
+    format: {
+        "quote-style": "double",
+    },
+};
+
+// Load the WASM module once; handlers below await this before doing any work so
+// messages that arrive during initialization aren't dropped.
+const ready = (async () => {
+    await init();
+    return new RuffServer(new Workspace(RUFF_CONFIG, PositionEncoding.Utf16));
+})();
+
+serve({
+    requests: {
+        initialize: async () => (await ready).initializeResult(),
+        "textDocument/codeAction": async (params) =>
+            (await ready).codeAction(params as LSP.CodeActionParams),
+    },
+    notifications: {
+        "textDocument/didOpen": async (params) => {
+            const server = await ready;
+            const { textDocument } = params as LSP.DidOpenTextDocumentParams;
+            publishDiagnostics(
+                server.setDocument(textDocument.uri, textDocument.text),
+            );
+        },
+        "textDocument/didChange": async (params) => {
+            const server = await ready;
+            const { textDocument, contentChanges } =
+                params as LSP.DidChangeTextDocumentParams;
+            const change = contentChanges[0];
+            if (change) {
+                publishDiagnostics(
+                    server.setDocument(textDocument.uri, change.text),
+                );
+            }
+        },
+    },
+});

--- a/demo/shared/workerRpc.ts
+++ b/demo/shared/workerRpc.ts
@@ -1,0 +1,64 @@
+/// <reference lib="webworker" />
+import type * as LSP from "vscode-languageserver-protocol";
+
+/**
+ * Minimal worker-side JSON-RPC dispatch loop, the counterpart to
+ * {@link WorkerTransport}. Register `requests` (must return a result) and
+ * `notifications` (fire-and-forget) keyed by LSP method name and call
+ * {@link serve}. Handlers receive the raw params and cast to the LSP type.
+ */
+export type RequestHandler = (params: unknown) => unknown | Promise<unknown>;
+export type NotificationHandler = (params: unknown) => void | Promise<void>;
+
+export interface ServeHandlers {
+    requests?: Record<string, RequestHandler>;
+    notifications?: Record<string, NotificationHandler>;
+}
+
+interface IncomingMessage {
+    id?: string | number | null;
+    method: string;
+    params: unknown;
+}
+
+function post(message: unknown): void {
+    (self as DedicatedWorkerGlobalScope).postMessage(message);
+}
+
+export function serve(handlers: ServeHandlers): void {
+    self.onmessage = async (event: MessageEvent) => {
+        const { id, method, params } = event.data as IncomingMessage;
+
+        // No id => JSON-RPC notification (didOpen/didChange/initialized/...).
+        if (id == null) {
+            await handlers.notifications?.[method]?.(params);
+            return;
+        }
+
+        try {
+            const handler = handlers.requests?.[method];
+            const result = handler ? await handler(params) : null;
+            post({ jsonrpc: "2.0", id, result: result ?? null });
+        } catch (error) {
+            post({
+                jsonrpc: "2.0",
+                id,
+                error: {
+                    code: -32000,
+                    message:
+                        error instanceof Error ? error.message : String(error),
+                    data: null,
+                },
+            });
+        }
+    };
+}
+
+/** Push a `textDocument/publishDiagnostics` notification to the main thread. */
+export function publishDiagnostics(params: LSP.PublishDiagnosticsParams): void {
+    post({
+        jsonrpc: "2.0",
+        method: "textDocument/publishDiagnostics",
+        params,
+    });
+}

--- a/demo/shared/workerTransport.ts
+++ b/demo/shared/workerTransport.ts
@@ -1,0 +1,73 @@
+import { getNotifications } from "@open-rpc/client-js/build/Request";
+import type {
+    IJSONRPCData,
+    JSONRPCRequestData,
+} from "@open-rpc/client-js/build/Request";
+import { Transport } from "@open-rpc/client-js/build/transports/Transport";
+import type * as LSP from "vscode-languageserver-protocol";
+import { LanguageServerClient } from "../../src";
+
+/**
+ * An `@open-rpc/client-js` transport that speaks JSON-RPC to a Web Worker via
+ * `postMessage`. It mirrors the built-in `PostMessageWindowTransport`: every
+ * inbound message is fed to the request manager (which matches responses by id
+ * and dispatches notifications), and outbound requests are posted verbatim.
+ *
+ * Notifications (`initialized`, `textDocument/didOpen`, `textDocument/didChange`)
+ * have no id, so `settlePendingRequest` resolves their `sendData` promise
+ * immediately — the client never waits on the worker for a fire-and-forget call.
+ */
+export class WorkerTransport extends Transport {
+    private worker: Worker;
+
+    private messageHandler = (event: MessageEvent) => {
+        this.transportRequestManager.resolveResponse(
+            JSON.stringify(event.data),
+        );
+    };
+
+    constructor(worker: Worker) {
+        super();
+        this.worker = worker;
+    }
+
+    connect(): Promise<void> {
+        this.worker.addEventListener("message", this.messageHandler);
+        return Promise.resolve();
+    }
+
+    close(): void {
+        this.worker.removeEventListener("message", this.messageHandler);
+        this.worker.terminate();
+    }
+
+    async sendData(
+        data: JSONRPCRequestData,
+        timeout: number | null = null,
+    ): Promise<unknown> {
+        const promise = this.transportRequestManager.addRequest(data, timeout);
+        const notifications = getNotifications(data);
+        this.worker.postMessage((data as IJSONRPCData).request);
+        this.transportRequestManager.settlePendingRequest(notifications);
+        return promise;
+    }
+}
+
+/**
+ * Convenience factory: wraps a worker in a {@link WorkerTransport} and returns a
+ * configured {@link LanguageServerClient} ready to hand to
+ * `languageServerWithClient`.
+ */
+export function createWorkerClient(
+    worker: Worker,
+    options?: {
+        rootUri?: string;
+        workspaceFolders?: LSP.WorkspaceFolder[] | null;
+    },
+): LanguageServerClient {
+    return new LanguageServerClient({
+        rootUri: options?.rootUri ?? "file:///",
+        workspaceFolders: options?.workspaceFolders ?? null,
+        transport: new WorkerTransport(worker),
+    });
+}

--- a/demo/typescript/tsDemo.ts
+++ b/demo/typescript/tsDemo.ts
@@ -1,0 +1,81 @@
+import { javascript } from "@codemirror/lang-javascript";
+import { lintGutter } from "@codemirror/lint";
+import { EditorState } from "@codemirror/state";
+import { EditorView, tooltips } from "@codemirror/view";
+import { basicSetup } from "codemirror";
+import { languageServerWithClient } from "../../src";
+import { createWorkerClient } from "../shared/workerTransport";
+
+const DOCUMENT_URI = "file:///index.ts";
+
+const SAMPLE = `// TypeScript running entirely in your browser (typescript + @typescript/vfs).
+// Try these features:
+//  - Hover over 'greet' or 'user' to see inferred types
+//  - Type 'user.' for completions
+//  - Ctrl/Cmd+Click 'greet' to jump to its definition
+//  - Put the cursor inside greet(...) for signature help
+//  - Press F2 on 'user' to rename it
+//  - The line below has a type error on purpose
+
+interface User {
+    name: string;
+    age: number;
+}
+
+function greet(user: User): string {
+    return \`Hello, \${user.name} (\${user.age})\`;
+}
+
+const user: User = { name: "Ada", age: 36 };
+console.log(greet(user));
+
+const wrong: number = "not a number";
+`;
+
+/**
+ * Mounts a TypeScript editor backed by a TS language service (over
+ * `@typescript/vfs`) running in a Web Worker. Exercises completion, hover,
+ * go-to-definition, diagnostics, signature help, and rename.
+ */
+export function mountTypeScriptDemo(container: HTMLElement): () => void {
+    const hint = document.createElement("p");
+    hint.className = "demo-hint";
+    hint.innerHTML =
+        "Backed by <code>typescript</code> + <code>@typescript/vfs</code> in a " +
+        "Web Worker. Type libraries stream from a CDN on first load, so give " +
+        "diagnostics a moment to appear.";
+    container.appendChild(hint);
+
+    const worker = new Worker(new URL("./worker.ts", import.meta.url), {
+        type: "module",
+    });
+    const client = createWorkerClient(worker, { rootUri: "file:///" });
+
+    const view = new EditorView({
+        state: EditorState.create({
+            doc: SAMPLE,
+            extensions: [
+                basicSetup,
+                javascript({ typescript: true }),
+                tooltips({ position: "absolute" }),
+                lintGutter(),
+                languageServerWithClient({
+                    client,
+                    documentUri: DOCUMENT_URI,
+                    languageId: "typescript",
+                    allowHTMLContent: true,
+                    sendIncrementalChanges: false,
+                    onGoToDefinition: (result) => {
+                        console.debug("Go to definition", result);
+                    },
+                }),
+            ],
+        }),
+        parent: container,
+    });
+
+    return () => {
+        view.destroy();
+        client.close();
+    };
+}

--- a/demo/typescript/tsServer.ts
+++ b/demo/typescript/tsServer.ts
@@ -1,0 +1,326 @@
+import type { VirtualTypeScriptEnvironment } from "@typescript/vfs";
+import * as ts from "typescript";
+import type * as LSP from "vscode-languageserver-protocol";
+import {
+    CompletionItemKind,
+    DiagnosticSeverity,
+    TextDocumentSyncKind,
+} from "vscode-languageserver-protocol";
+
+interface CompletionData {
+    offset: number;
+    name: string;
+    source?: string;
+}
+
+/**
+ * An LSP server backed by a TypeScript `LanguageService` running over an
+ * in-memory virtual file system (`@typescript/vfs`). A single virtual file holds
+ * the editor's content; every request maps LSP positions (0-based line/char) to
+ * TypeScript offsets via the current `SourceFile`.
+ */
+export class TsServer {
+    private documentUri = "file:///index.ts";
+
+    constructor(
+        private env: VirtualTypeScriptEnvironment,
+        private fileName: string,
+    ) {}
+
+    private get ls(): ts.LanguageService {
+        return this.env.languageService;
+    }
+
+    static initializeResult(): LSP.InitializeResult {
+        return {
+            capabilities: {
+                textDocumentSync: TextDocumentSyncKind.Full,
+                completionProvider: {
+                    resolveProvider: true,
+                    triggerCharacters: ["."],
+                },
+                hoverProvider: true,
+                definitionProvider: true,
+                signatureHelpProvider: {
+                    triggerCharacters: ["(", ","],
+                    retriggerCharacters: [","],
+                },
+                renameProvider: { prepareProvider: true },
+            },
+        };
+    }
+
+    setDocument(uri: string, text: string): LSP.PublishDiagnosticsParams {
+        this.documentUri = uri;
+        this.env.updateFile(this.fileName, text);
+        return this.getDiagnostics(uri);
+    }
+
+    getDiagnostics(uri: string): LSP.PublishDiagnosticsParams {
+        const raw = [
+            ...this.ls.getSyntacticDiagnostics(this.fileName),
+            ...this.ls.getSemanticDiagnostics(this.fileName),
+        ];
+        return {
+            uri,
+            diagnostics: raw.map((diagnostic) =>
+                this.toLspDiagnostic(diagnostic),
+            ),
+        };
+    }
+
+    completion(params: LSP.CompletionParams): LSP.CompletionList {
+        const offset = this.offsetAt(params.position);
+        const info = this.ls.getCompletionsAtPosition(
+            this.fileName,
+            offset,
+            {},
+        );
+        if (!info) {
+            return { isIncomplete: false, items: [] };
+        }
+        const items = info.entries.map((entry): LSP.CompletionItem => {
+            const data: CompletionData = {
+                offset,
+                name: entry.name,
+                source: entry.source,
+            };
+            return {
+                label: entry.name,
+                kind: mapCompletionKind(entry.kind),
+                sortText: entry.sortText,
+                insertText: entry.insertText,
+                data,
+            };
+        });
+        return { isIncomplete: false, items };
+    }
+
+    completionResolve(item: LSP.CompletionItem): LSP.CompletionItem {
+        const data = item.data as CompletionData | undefined;
+        if (!data) {
+            return item;
+        }
+        const details = this.ls.getCompletionEntryDetails(
+            this.fileName,
+            data.offset,
+            data.name,
+            undefined,
+            data.source,
+            undefined,
+            undefined,
+        );
+        if (!details) {
+            return item;
+        }
+        const detail = ts.displayPartsToString(details.displayParts);
+        const documentation = ts.displayPartsToString(details.documentation);
+        return {
+            ...item,
+            detail: detail || item.detail,
+            documentation: documentation
+                ? { kind: "markdown", value: documentation }
+                : item.documentation,
+        };
+    }
+
+    hover(params: LSP.HoverParams): LSP.Hover | null {
+        const offset = this.offsetAt(params.position);
+        const info = this.ls.getQuickInfoAtPosition(this.fileName, offset);
+        if (!info) {
+            return null;
+        }
+        const display = ts.displayPartsToString(info.displayParts);
+        const documentation = ts.displayPartsToString(info.documentation);
+        const value = ["```typescript", display, "```", documentation]
+            .filter(Boolean)
+            .join("\n");
+        return {
+            contents: { kind: "markdown", value },
+            range: this.rangeFromSpan(this.fileName, info.textSpan),
+        };
+    }
+
+    definition(params: LSP.DefinitionParams): LSP.Location[] {
+        const offset = this.offsetAt(params.position);
+        const definitions = this.ls.getDefinitionAtPosition(
+            this.fileName,
+            offset,
+        );
+        if (!definitions) {
+            return [];
+        }
+        return definitions.map((definition) => ({
+            uri:
+                definition.fileName === this.fileName
+                    ? this.documentUri
+                    : `file:///${definition.fileName}`,
+            range: this.rangeFromSpan(definition.fileName, definition.textSpan),
+        }));
+    }
+
+    signatureHelp(params: LSP.SignatureHelpParams): LSP.SignatureHelp | null {
+        const offset = this.offsetAt(params.position);
+        const help = this.ls.getSignatureHelpItems(
+            this.fileName,
+            offset,
+            undefined,
+        );
+        if (!help) {
+            return null;
+        }
+        const signatures = help.items.map((item): LSP.SignatureInformation => {
+            const separator = ts.displayPartsToString(
+                item.separatorDisplayParts,
+            );
+            const label =
+                ts.displayPartsToString(item.prefixDisplayParts) +
+                item.parameters
+                    .map((parameter) =>
+                        ts.displayPartsToString(parameter.displayParts),
+                    )
+                    .join(separator) +
+                ts.displayPartsToString(item.suffixDisplayParts);
+            return {
+                label,
+                documentation: partsToMarkdown(item.documentation),
+                parameters: item.parameters.map((parameter) => ({
+                    label: ts.displayPartsToString(parameter.displayParts),
+                    documentation: partsToMarkdown(parameter.documentation),
+                })),
+            };
+        });
+        return {
+            signatures,
+            activeSignature: help.selectedItemIndex,
+            activeParameter: help.argumentIndex,
+        };
+    }
+
+    prepareRename(
+        params: LSP.PrepareRenameParams,
+    ): LSP.Range | { defaultBehavior: boolean } | null {
+        const offset = this.offsetAt(params.position);
+        const info = this.ls.getRenameInfo(this.fileName, offset, {
+            allowRenameOfImportPath: false,
+        });
+        if (!info.canRename) {
+            return null;
+        }
+        return this.rangeFromSpan(this.fileName, info.triggerSpan);
+    }
+
+    rename(params: LSP.RenameParams): LSP.WorkspaceEdit {
+        const offset = this.offsetAt(params.position);
+        const locations = this.ls.findRenameLocations(
+            this.fileName,
+            offset,
+            false,
+            false,
+            {},
+        );
+        const edits = (locations ?? [])
+            .filter((location) => location.fileName === this.fileName)
+            .map((location) => ({
+                range: this.rangeFromSpan(this.fileName, location.textSpan),
+                newText: params.newName,
+            }));
+        return { changes: { [this.documentUri]: edits } };
+    }
+
+    private toLspDiagnostic(diagnostic: ts.Diagnostic): LSP.Diagnostic {
+        const start = diagnostic.start ?? 0;
+        const length = diagnostic.length ?? 0;
+        return {
+            range: this.rangeFromSpan(this.fileName, { start, length }),
+            message: ts.flattenDiagnosticMessageText(
+                diagnostic.messageText,
+                "\n",
+            ),
+            code: diagnostic.code,
+            severity: mapCategory(diagnostic.category),
+            source: "ts",
+        };
+    }
+
+    private offsetAt(position: LSP.Position): number {
+        const sourceFile = this.env.getSourceFile(this.fileName);
+        if (!sourceFile) {
+            return 0;
+        }
+        return sourceFile.getPositionOfLineAndCharacter(
+            position.line,
+            position.character,
+        );
+    }
+
+    private rangeFromSpan(fileName: string, span: ts.TextSpan): LSP.Range {
+        const sourceFile = this.env.getSourceFile(fileName);
+        if (!sourceFile) {
+            const zero = { line: 0, character: 0 };
+            return { start: zero, end: zero };
+        }
+        return {
+            start: sourceFile.getLineAndCharacterOfPosition(span.start),
+            end: sourceFile.getLineAndCharacterOfPosition(
+                span.start + span.length,
+            ),
+        };
+    }
+}
+
+function partsToMarkdown(
+    parts: ts.SymbolDisplayPart[] | undefined,
+): LSP.MarkupContent | undefined {
+    const value = ts.displayPartsToString(parts);
+    return value ? { kind: "markdown", value } : undefined;
+}
+
+function mapCategory(category: ts.DiagnosticCategory): LSP.DiagnosticSeverity {
+    switch (category) {
+        case ts.DiagnosticCategory.Error:
+            return DiagnosticSeverity.Error;
+        case ts.DiagnosticCategory.Warning:
+            return DiagnosticSeverity.Warning;
+        case ts.DiagnosticCategory.Suggestion:
+            return DiagnosticSeverity.Hint;
+        default:
+            return DiagnosticSeverity.Information;
+    }
+}
+
+function mapCompletionKind(kind: ts.ScriptElementKind): LSP.CompletionItemKind {
+    switch (kind) {
+        case ts.ScriptElementKind.memberFunctionElement:
+        case ts.ScriptElementKind.functionElement:
+        case ts.ScriptElementKind.localFunctionElement:
+            return CompletionItemKind.Function;
+        case ts.ScriptElementKind.memberVariableElement:
+        case ts.ScriptElementKind.memberGetAccessorElement:
+        case ts.ScriptElementKind.memberSetAccessorElement:
+            return CompletionItemKind.Field;
+        case ts.ScriptElementKind.constructorImplementationElement:
+            return CompletionItemKind.Constructor;
+        case ts.ScriptElementKind.enumElement:
+            return CompletionItemKind.Enum;
+        case ts.ScriptElementKind.enumMemberElement:
+            return CompletionItemKind.EnumMember;
+        case ts.ScriptElementKind.variableElement:
+        case ts.ScriptElementKind.localVariableElement:
+        case ts.ScriptElementKind.letElement:
+        case ts.ScriptElementKind.constElement:
+            return CompletionItemKind.Variable;
+        case ts.ScriptElementKind.classElement:
+            return CompletionItemKind.Class;
+        case ts.ScriptElementKind.interfaceElement:
+            return CompletionItemKind.Interface;
+        case ts.ScriptElementKind.moduleElement:
+            return CompletionItemKind.Module;
+        case ts.ScriptElementKind.keyword:
+            return CompletionItemKind.Keyword;
+        case ts.ScriptElementKind.typeParameterElement:
+            return CompletionItemKind.TypeParameter;
+        default:
+            return CompletionItemKind.Text;
+    }
+}

--- a/demo/typescript/worker.ts
+++ b/demo/typescript/worker.ts
@@ -1,0 +1,84 @@
+import {
+    createDefaultMapFromCDN,
+    createSystem,
+    createVirtualTypeScriptEnvironment,
+} from "@typescript/vfs";
+import * as ts from "typescript";
+import type * as LSP from "vscode-languageserver-protocol";
+import { publishDiagnostics, serve } from "../shared/workerRpc";
+import { TsServer } from "./tsServer";
+
+// Must be an absolute path: the vfs System's cwd is "/", so TypeScript resolves
+// root files against it — a bare "index.ts" becomes "/index.ts" and isn't found.
+const FILE_NAME = "/index.ts";
+
+const COMPILER_OPTIONS: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ES2020,
+    lib: ["lib.es2020.d.ts", "lib.dom.d.ts"],
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    strict: true,
+};
+
+// Building the environment fetches the TypeScript lib .d.ts files from a CDN
+// (~1-2 MB), so it's async. Handlers await this; `initialize` does not, so the
+// client can finish its handshake while the libs stream in.
+const ready = (async () => {
+    const fsMap = await createDefaultMapFromCDN(
+        COMPILER_OPTIONS,
+        ts.version,
+        // cache=false: no localStorage inside a worker.
+        false,
+        ts,
+    );
+    // Seed with non-empty content: vfs's getScriptSnapshot treats "" as falsy
+    // and reports the file missing. didOpen replaces this immediately.
+    fsMap.set(FILE_NAME, "\n");
+    const env = createVirtualTypeScriptEnvironment(
+        createSystem(fsMap),
+        [FILE_NAME],
+        ts,
+        COMPILER_OPTIONS,
+    );
+    return new TsServer(env, FILE_NAME);
+})();
+
+serve({
+    requests: {
+        initialize: () => TsServer.initializeResult(),
+        "textDocument/completion": async (params) =>
+            (await ready).completion(params as LSP.CompletionParams),
+        "completionItem/resolve": async (params) =>
+            (await ready).completionResolve(params as LSP.CompletionItem),
+        "textDocument/hover": async (params) =>
+            (await ready).hover(params as LSP.HoverParams),
+        "textDocument/definition": async (params) =>
+            (await ready).definition(params as LSP.DefinitionParams),
+        "textDocument/signatureHelp": async (params) =>
+            (await ready).signatureHelp(params as LSP.SignatureHelpParams),
+        "textDocument/prepareRename": async (params) =>
+            (await ready).prepareRename(params as LSP.PrepareRenameParams),
+        "textDocument/rename": async (params) =>
+            (await ready).rename(params as LSP.RenameParams),
+    },
+    notifications: {
+        "textDocument/didOpen": async (params) => {
+            const server = await ready;
+            const { textDocument } = params as LSP.DidOpenTextDocumentParams;
+            publishDiagnostics(
+                server.setDocument(textDocument.uri, textDocument.text),
+            );
+        },
+        "textDocument/didChange": async (params) => {
+            const server = await ready;
+            const { textDocument, contentChanges } =
+                params as LSP.DidChangeTextDocumentParams;
+            const change = contentChanges[0];
+            if (change) {
+                publishDiagnostics(
+                    server.setDocument(textDocument.uri, change.text),
+                );
+            }
+        },
+    },
+});

--- a/package.json
+++ b/package.json
@@ -49,18 +49,21 @@
         "@codemirror/lang-javascript": "^6.2.2",
         "@codemirror/state": "^6.5.2",
         "@codemirror/view": "^6.36.2",
+        "@vitest/coverage-v8": "3.2.4",
         "codemirror": "6.0.2",
         "events": "3.3.0",
         "jsdom": "26.1.0",
         "typescript": "5.9.3",
         "vite": "6.4.2",
-        "vitest": "3.2.4",
-        "@vitest/coverage-v8": "3.2.4"
+        "vitest": "3.2.4"
     },
     "dependencies": {
+        "@astral-sh/ruff-wasm-web": "^0.15.20",
         "@codemirror/autocomplete": "^6.18.4",
+        "@codemirror/lang-python": "^6.2.1",
         "@codemirror/lint": "^6.8.4",
         "@open-rpc/client-js": "^1.8.1",
+        "@typescript/vfs": "^1.6.4",
         "marked": "^15.0.6",
         "vscode-languageserver-protocol": "^3.17.5"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,15 +8,24 @@ importers:
 
   .:
     dependencies:
+      '@astral-sh/ruff-wasm-web':
+        specifier: ^0.15.20
+        version: 0.15.20
       '@codemirror/autocomplete':
         specifier: ^6.18.4
         version: 6.20.1
+      '@codemirror/lang-python':
+        specifier: ^6.2.1
+        version: 6.2.1
       '@codemirror/lint':
         specifier: ^6.8.4
         version: 6.9.5
       '@open-rpc/client-js':
         specifier: ^1.8.1
         version: 1.8.1
+      '@typescript/vfs':
+        specifier: ^1.6.4
+        version: 1.6.4(typescript@5.9.3)
       marked:
         specifier: ^15.0.6
         version: 15.0.12
@@ -66,6 +75,9 @@ packages:
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
+  '@astral-sh/ruff-wasm-web@0.15.20':
+    resolution: {integrity: sha512-co/P+BHgKurWeAQRBLY2rCrsD5320P1fP7rkM24ZxCEl8UoyjbJth3i/zv18cvYED7xeGjwZsncyMXj8i5GmOA==}
 
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
@@ -153,6 +165,9 @@ packages:
 
   '@codemirror/lang-javascript@6.2.5':
     resolution: {integrity: sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==}
+
+  '@codemirror/lang-python@6.2.1':
+    resolution: {integrity: sha512-IRjC8RUBhn9mGR9ywecNhB51yePWCGgvHfY1lWN/Mrp3cKuHr0isDKia+9HnvhiWNnMpbGhWrkhuWOc09exRyw==}
 
   '@codemirror/language@6.12.3':
     resolution: {integrity: sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==}
@@ -386,6 +401,9 @@ packages:
   '@lezer/lr@1.4.10':
     resolution: {integrity: sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==}
 
+  '@lezer/python@1.1.19':
+    resolution: {integrity: sha512-MhQIURHRytsNzP/YXnqpYKW6la6voAH3kyplTOOiCdjyFY6cWWGFVmYVdHIPrElqSDf4iCDktQCockB9FxuhzQ==}
+
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
@@ -542,6 +560,11 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@typescript/vfs@1.6.4':
+    resolution: {integrity: sha512-PJFXFS4ZJKiJ9Qiuix6Dz/OwEIqHD7Dme1UwZhTK11vR+5dqW2ACbdndWQexBzCx+CPuMe5WBYQWCsFyGlQLlQ==}
+    peerDependencies:
+      typescript: '*'
 
   '@vitest/coverage-v8@3.2.4':
     resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
@@ -1200,6 +1223,8 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
 
+  '@astral-sh/ruff-wasm-web@0.15.20': {}
+
   '@babel/helper-string-parser@7.29.7': {}
 
   '@babel/helper-validator-identifier@7.29.7': {}
@@ -1273,6 +1298,14 @@ snapshots:
       '@codemirror/view': 6.41.1
       '@lezer/common': 1.5.2
       '@lezer/javascript': 1.5.4
+
+  '@codemirror/lang-python@6.2.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/python': 1.1.19
 
   '@codemirror/language@6.12.3':
     dependencies:
@@ -1445,6 +1478,12 @@ snapshots:
     dependencies:
       '@lezer/common': 1.5.2
 
+  '@lezer/python@1.1.19':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
   '@marijn/find-cluster-break@1.0.2': {}
 
   '@open-rpc/client-js@1.8.1':
@@ -1544,6 +1583,13 @@ snapshots:
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
+
+  '@typescript/vfs@1.6.4(typescript@5.9.3)':
+    dependencies:
+      debug: 4.4.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@vitest/coverage-v8@3.2.4(vitest@3.2.4(jsdom@26.1.0))':
     dependencies:

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,18 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
     root: process.env.VITEST ? "." : "demo",
+    // ESM module workers so the demo workers can use top-level await / imports.
+    worker: { format: "es" },
+    build: {
+        // Top-level await in the ruff/typescript workers.
+        target: "esnext",
+    },
+    optimizeDeps: {
+        // ruff-wasm-web resolves its .wasm via import.meta.url; pre-bundling
+        // breaks that, so keep it external during dev.
+        exclude: ["@astral-sh/ruff-wasm-web"],
+        esbuildOptions: { target: "esnext" },
+    },
     test: {
         globals: true,
         environment: "jsdom",


### PR DESCRIPTION
Turns the single mock demo into a tabbed page with three language servers, all running in the browser (WASM + Web Workers) and routed through this package's own `LanguageServerClient` so the client's features are exercised against real servers.

- **Mock** — the existing in-memory server, unchanged behavior, extracted into `demo/mock/mockDemo.ts`.
- **Python** — `@astral-sh/ruff-wasm-web` in a worker: diagnostics + quick-fix / fix-all / format-document code actions.
- **TypeScript** — `typescript` + `@typescript/vfs` in a worker: diagnostics, completion (+resolve), hover, go-to-definition, signature help, and rename.

Infra: a reusable `WorkerTransport` (open-rpc `Transport` over `postMessage`) + a worker-side JSON-RPC dispatch loop; Vite configured for ESM workers, wasm, and top-level await.

Verified in Chromium: Ruff underlines land exactly on the offending tokens with all three code actions; TS flags type errors, completes real `User` members, and F2-rename is scope-aware (renames only the intended binding). `lint:ci`, `tsc` build, `build:demo`, and the 294-test suite all pass.

Note: hover / go-to-def tooltips couldn't be driven via synthetic mouse events in automation (CodeMirror mousemove tracking), but share the same worker-request + offset-mapping path as the verified features.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the single mock demo with a tabbed, in-browser LSP playground running Mock, Python (Ruff WASM), and TypeScript (`typescript` + `@typescript/vfs`) servers in Web Workers via the `LanguageServerClient`. Adds real diagnostics, code actions, completion, hover, go-to-definition, signature help, and rename.

- New Features
  - Tabbed demo page with three servers running fully in the browser.
  - Python — `@astral-sh/ruff-wasm-web` in a worker: diagnostics, quick-fix, fix-all, and format-document actions.
  - TypeScript — `typescript` + `@typescript/vfs` in a worker: diagnostics, completion (+resolve), hover, go-to-definition, signature help, and rename.
  - Infra: reusable `WorkerTransport` (open-rpc over `postMessage`) and a worker JSON-RPC loop; Vite configured for ESM workers, WASM, and top-level await.

- Dependencies
  - Added `@astral-sh/ruff-wasm-web`, `@typescript/vfs`, and `@codemirror/lang-python`.
  - Vite tweaks: exclude `@astral-sh/ruff-wasm-web` from pre-bundling; target `esnext` for worker builds.

<sup>Written for commit b503b43491cce821feeaf2f2b2843ce6d294771a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marimo-team/codemirror-languageserver/pull/75?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

