### PR TITLE
demo: optional ty type-checking alongside Ruff in the Python tab

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Vendored ty_wasm build (see scripts/build-ty-wasm.sh) — treat as generated
+# binary so diffs stay collapsed and it's excluded from language stats.
+demo/vendor/ty_wasm/** linguist-generated=true
+demo/vendor/ty_wasm/*.wasm binary

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,6 @@ coverage
 
 *.sublime-*
 
-# Locally-built ty WASM artifact and its ruff checkout (see scripts/build-ty-wasm.sh)
-demo/vendor/
+# ruff checkout used to build ty_wasm (see scripts/build-ty-wasm.sh).
+# The built artifact in demo/vendor/ty_wasm/ IS committed so GitHub Pages serves it.
 .cache/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ dist/
 coverage
 
 *.sublime-*
+
+# Locally-built ty WASM artifact and its ruff checkout (see scripts/build-ty-wasm.sh)
+demo/vendor/
+.cache/

--- a/README.md
+++ b/README.md
@@ -114,7 +114,23 @@ Please ensure your PR includes appropriate tests and documentation.
 
 ## Demo
 
-Check out our [live demo](https://github.com/mscolnick/codemirror-languageserver/tree/main/demo) to see the plugin in action.
+Check out our [live demo](https://github.com/mscolnick/codemirror-languageserver/tree/main/demo) to see the plugin in action. Run it locally with `pnpm dev`.
+
+The demo has three tabs, all running in the browser via Web Workers:
+
+- **Mock** — an in-memory language server.
+- **Python** — [Ruff](https://github.com/astral-sh/ruff) (`@astral-sh/ruff-wasm-web`) for lint diagnostics, quick-fixes, and formatting.
+- **TypeScript** — a TypeScript language service over [`@typescript/vfs`](https://github.com/microsoft/TypeScript-Website/tree/v2/packages/typescript-vfs) for completion, hover, go-to-definition, diagnostics, signature help, and rename.
+
+### Optional: ty type-checking in the Python tab
+
+The Python tab can additionally surface type-check diagnostics from [ty](https://github.com/astral-sh/ty) (Astral's type checker) alongside Ruff's lint output. `ty` is not published to npm, so build its WASM module once (requires a Rust toolchain and [`wasm-pack`](https://rustwasm.github.io/wasm-pack/installer/)):
+
+```bash
+pnpm build:ty-wasm
+```
+
+This clones ruff into `.cache/` and vendors the build into `demo/vendor/ty_wasm/` (both gitignored). When present, the Python worker loads it automatically; when absent, the demo falls back to Ruff only.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -114,23 +114,7 @@ Please ensure your PR includes appropriate tests and documentation.
 
 ## Demo
 
-Check out our [live demo](https://github.com/mscolnick/codemirror-languageserver/tree/main/demo) to see the plugin in action. Run it locally with `pnpm dev`.
-
-The demo has three tabs, all running in the browser via Web Workers:
-
-- **Mock** — an in-memory language server.
-- **Python** — [Ruff](https://github.com/astral-sh/ruff) (`@astral-sh/ruff-wasm-web`) for lint diagnostics, quick-fixes, and formatting.
-- **TypeScript** — a TypeScript language service over [`@typescript/vfs`](https://github.com/microsoft/TypeScript-Website/tree/v2/packages/typescript-vfs) for completion, hover, go-to-definition, diagnostics, signature help, and rename.
-
-### Optional: ty type-checking in the Python tab
-
-The Python tab can additionally surface type-check diagnostics from [ty](https://github.com/astral-sh/ty) (Astral's type checker) alongside Ruff's lint output. `ty` is not published to npm, so build its WASM module once (requires a Rust toolchain and [`wasm-pack`](https://rustwasm.github.io/wasm-pack/installer/)):
-
-```bash
-pnpm build:ty-wasm
-```
-
-This clones ruff into `.cache/` and vendors the build into `demo/vendor/ty_wasm/` (both gitignored). When present, the Python worker loads it automatically; when absent, the demo falls back to Ruff only.
+Check out our [live demo](https://github.com/mscolnick/codemirror-languageserver/tree/main/demo) to see the plugin in action.
 
 ## License
 

--- a/demo/python/pythonDemo.ts
+++ b/demo/python/pythonDemo.ts
@@ -12,26 +12,29 @@ const SAMPLE = `import os
 import sys
 
 
-def greet(name):
-    message = "Hello, " + name
-    print( message )
+def greet(name: str) -> str:
+    return "Hello, " + name
 
 
-greet("world")
+# Ruff flags the unused imports above; ty flags the type error below.
+message: int = greet("world")
+print( message )
 `;
 
 /**
- * Mounts a Python editor backed by Ruff (WASM) running in a Web Worker.
- * Exercises diagnostics, quick-fix / fix-all code actions, and formatting
- * (the latter two surface as actions in each diagnostic's tooltip).
+ * Mounts a Python editor backed by Ruff (WASM) running in a Web Worker, plus
+ * ty (Astral's type checker) when its WASM build has been vendored in.
+ * Exercises diagnostics (lint + type errors), quick-fix / fix-all code actions,
+ * and formatting (the latter surface as actions in each diagnostic's tooltip).
  */
 export function mountPythonDemo(container: HTMLElement): () => void {
     const hint = document.createElement("p");
     hint.className = "demo-hint";
     hint.innerHTML =
-        "Backed by <code>@astral-sh/ruff-wasm-web</code> in a Web Worker. " +
-        "Hover a diagnostic to see quick-fix, <em>Fix all</em>, and " +
-        "<em>Format document</em> actions.";
+        "Backed by <code>@astral-sh/ruff-wasm-web</code> (lint + format) in a " +
+        "Web Worker, plus <code>ty</code> type-checking when built via " +
+        "<code>pnpm build:ty-wasm</code>. Hover a diagnostic for quick-fix, " +
+        "<em>Fix all</em>, and <em>Format document</em> actions.";
     container.appendChild(hint);
 
     const worker = new Worker(new URL("./worker.ts", import.meta.url), {

--- a/demo/python/pythonDemo.ts
+++ b/demo/python/pythonDemo.ts
@@ -21,12 +21,8 @@ message: int = greet("world")
 print( message )
 `;
 
-/**
- * Mounts a Python editor backed by Ruff (WASM) running in a Web Worker, plus
- * ty (Astral's type checker) when its WASM build has been vendored in.
- * Exercises diagnostics (lint + type errors), quick-fix / fix-all code actions,
- * and formatting (the latter surface as actions in each diagnostic's tooltip).
- */
+// Python editor backed by Ruff (and ty, when its WASM build is vendored in),
+// both in a Web Worker.
 export function mountPythonDemo(container: HTMLElement): () => void {
     const hint = document.createElement("p");
     hint.className = "demo-hint";

--- a/demo/python/ruffServer.ts
+++ b/demo/python/ruffServer.ts
@@ -7,6 +7,7 @@ import {
     DiagnosticSeverity,
     TextDocumentSyncKind,
 } from "vscode-languageserver-protocol";
+import { rangesOverlap } from "../shared/ranges";
 
 type RuffFix = NonNullable<RuffDiagnostic["fix"]>;
 
@@ -162,15 +163,4 @@ function wholeDocumentEdit(text: string, newText: string): LSP.TextEdit {
         },
         newText,
     };
-}
-
-function rangesOverlap(a: LSP.Range, b: LSP.Range): boolean {
-    return !(isBefore(a.end, b.start) || isBefore(b.end, a.start));
-}
-
-function isBefore(a: LSP.Position, b: LSP.Position): boolean {
-    if (a.line !== b.line) {
-        return a.line < b.line;
-    }
-    return a.character < b.character;
 }

--- a/demo/python/tyServer.ts
+++ b/demo/python/tyServer.ts
@@ -1,0 +1,168 @@
+import type * as LSP from "vscode-languageserver-protocol";
+import { DiagnosticSeverity } from "vscode-languageserver-protocol";
+
+/**
+ * Minimal structural types for the `ty_wasm` module. `ty_wasm` is not published
+ * to npm — it must be built from the crate with
+ * `wasm-pack build crates/ty_wasm --target web` (see scripts/build-ty-wasm.sh)
+ * and vendored into demo/vendor/ty_wasm/. We type only what we use so the demo
+ * still type-checks/builds when the artifact isn't present.
+ *
+ * ty's `Position` is 1-indexed for both line and column; LSP is 0-indexed.
+ */
+interface TyPosition {
+    line: number;
+    column: number;
+}
+interface TyRange {
+    start: TyPosition;
+    end: TyPosition;
+}
+interface TyTextEdit {
+    range: TyRange;
+    new_text: string;
+}
+interface TyCodeAction {
+    title: string;
+    edits: TyTextEdit[];
+    preferred: boolean;
+}
+interface TyDiagnostic {
+    message(): string;
+    id(): string;
+    severity(): number;
+    toRange(workspace: TyWorkspace): TyRange | undefined;
+    codeAction(workspace: TyWorkspace): TyCodeAction | undefined;
+}
+interface TyFileHandle {
+    path(): string;
+}
+export interface TyWorkspace {
+    openFile(path: string, contents: string): TyFileHandle;
+    updateFile(handle: TyFileHandle, contents: string): void;
+    checkFile(handle: TyFileHandle): TyDiagnostic[];
+}
+
+// The `Severity` wasm enum: Info=0, Warning=1, Error=2, Fatal=3.
+enum TySeverity {
+    Info = 0,
+    Warning = 1,
+    Error = 2,
+    Fatal = 3,
+}
+
+const FILE_PATH = "main.py";
+
+/**
+ * Wraps a `ty` (Astral's type checker) WASM workspace and maps its type-check
+ * diagnostics and fixes onto LSP shapes, so they can be merged with Ruff's lint
+ * output in the same Python document.
+ */
+export class TyServer {
+    private handles = new Map<string, TyFileHandle>();
+
+    constructor(private workspace: TyWorkspace) {}
+
+    /** Update the file in ty's workspace and return its diagnostics. */
+    setDocument(uri: string, text: string): LSP.Diagnostic[] {
+        const handle = this.handle(uri, text);
+        return this.diagnostics(handle);
+    }
+
+    codeAction(params: LSP.CodeActionParams): LSP.CodeAction[] {
+        const uri = params.textDocument.uri;
+        const handle = this.handles.get(uri);
+        if (!handle) {
+            return [];
+        }
+        const actions: LSP.CodeAction[] = [];
+        for (const diagnostic of this.workspace.checkFile(handle)) {
+            const tyRange = diagnostic.toRange(this.workspace);
+            if (!(tyRange && rangesOverlap(toRange(tyRange), params.range))) {
+                continue;
+            }
+            const action = diagnostic.codeAction(this.workspace);
+            if (!action) {
+                continue;
+            }
+            actions.push({
+                title: `${action.title} (ty)`,
+                kind: "quickfix",
+                isPreferred: action.preferred,
+                edit: {
+                    changes: {
+                        [uri]: action.edits.map((edit) => ({
+                            range: toRange(edit.range),
+                            newText: edit.new_text,
+                        })),
+                    },
+                },
+            });
+        }
+        return actions;
+    }
+
+    private handle(uri: string, text: string): TyFileHandle {
+        const existing = this.handles.get(uri);
+        if (existing) {
+            this.workspace.updateFile(existing, text);
+            return existing;
+        }
+        const handle = this.workspace.openFile(FILE_PATH, text);
+        this.handles.set(uri, handle);
+        return handle;
+    }
+
+    private diagnostics(handle: TyFileHandle): LSP.Diagnostic[] {
+        const result: LSP.Diagnostic[] = [];
+        for (const diagnostic of this.workspace.checkFile(handle)) {
+            const tyRange = diagnostic.toRange(this.workspace);
+            if (!tyRange) {
+                continue;
+            }
+            result.push({
+                range: toRange(tyRange),
+                message: diagnostic.message(),
+                code: diagnostic.id(),
+                severity: toSeverity(diagnostic.severity()),
+                source: "ty",
+            });
+        }
+        return result;
+    }
+}
+
+function toRange(range: TyRange): LSP.Range {
+    return {
+        start: toPosition(range.start),
+        end: toPosition(range.end),
+    };
+}
+
+function toPosition(position: TyPosition): LSP.Position {
+    // ty positions are 1-indexed; LSP is 0-indexed.
+    return { line: position.line - 1, character: position.column - 1 };
+}
+
+function toSeverity(severity: number): LSP.DiagnosticSeverity {
+    switch (severity) {
+        case TySeverity.Error:
+        case TySeverity.Fatal:
+            return DiagnosticSeverity.Error;
+        case TySeverity.Warning:
+            return DiagnosticSeverity.Warning;
+        default:
+            return DiagnosticSeverity.Information;
+    }
+}
+
+function rangesOverlap(a: LSP.Range, b: LSP.Range): boolean {
+    return !(isBefore(a.end, b.start) || isBefore(b.end, a.start));
+}
+
+function isBefore(a: LSP.Position, b: LSP.Position): boolean {
+    if (a.line !== b.line) {
+        return a.line < b.line;
+    }
+    return a.character < b.character;
+}

--- a/demo/python/tyServer.ts
+++ b/demo/python/tyServer.ts
@@ -1,15 +1,8 @@
 import type * as LSP from "vscode-languageserver-protocol";
 import { DiagnosticSeverity } from "vscode-languageserver-protocol";
 
-/**
- * Minimal structural types for the `ty_wasm` module. `ty_wasm` is not published
- * to npm — it must be built from the crate with
- * `wasm-pack build crates/ty_wasm --target web` (see scripts/build-ty-wasm.sh)
- * and vendored into demo/vendor/ty_wasm/. We type only what we use so the demo
- * still type-checks/builds when the artifact isn't present.
- *
- * ty's `Position` is 1-indexed for both line and column; LSP is 0-indexed.
- */
+// Structural types for the subset of the ty_wasm module we use. ty positions
+// are 1-indexed; LSP is 0-indexed.
 interface TyPosition {
     line: number;
     column: number;
@@ -43,7 +36,6 @@ export interface TyWorkspace {
     checkFile(handle: TyFileHandle): TyDiagnostic[];
 }
 
-// The `Severity` wasm enum: Info=0, Warning=1, Error=2, Fatal=3.
 enum TySeverity {
     Info = 0,
     Warning = 1,
@@ -53,17 +45,12 @@ enum TySeverity {
 
 const FILE_PATH = "main.py";
 
-/**
- * Wraps a `ty` (Astral's type checker) WASM workspace and maps its type-check
- * diagnostics and fixes onto LSP shapes, so they can be merged with Ruff's lint
- * output in the same Python document.
- */
+// Maps ty's type-check diagnostics and fixes onto LSP shapes.
 export class TyServer {
     private handles = new Map<string, TyFileHandle>();
 
     constructor(private workspace: TyWorkspace) {}
 
-    /** Update the file in ty's workspace and return its diagnostics. */
     setDocument(uri: string, text: string): LSP.Diagnostic[] {
         const handle = this.handle(uri, text);
         return this.diagnostics(handle);
@@ -140,7 +127,6 @@ function toRange(range: TyRange): LSP.Range {
 }
 
 function toPosition(position: TyPosition): LSP.Position {
-    // ty positions are 1-indexed; LSP is 0-indexed.
     return { line: position.line - 1, character: position.column - 1 };
 }
 

--- a/demo/python/tyServer.ts
+++ b/demo/python/tyServer.ts
@@ -1,5 +1,6 @@
 import type * as LSP from "vscode-languageserver-protocol";
 import { DiagnosticSeverity } from "vscode-languageserver-protocol";
+import { rangesOverlap } from "../shared/ranges";
 
 // Structural types for the subset of the ty_wasm module we use. ty positions
 // are 1-indexed; LSP is 0-indexed.
@@ -25,7 +26,6 @@ interface TyDiagnostic {
     id(): string;
     severity(): number;
     toRange(workspace: TyWorkspace): TyRange | undefined;
-    codeAction(workspace: TyWorkspace): TyCodeAction | undefined;
 }
 interface TyFileHandle {
     path(): string;
@@ -34,6 +34,12 @@ export interface TyWorkspace {
     openFile(path: string, contents: string): TyFileHandle;
     updateFile(handle: TyFileHandle, contents: string): void;
     checkFile(handle: TyFileHandle): TyDiagnostic[];
+    // Superset of Diagnostic.codeAction: also returns workspace-derived actions
+    // (e.g. import suggestions) that need whole-project analysis.
+    codeActions(
+        handle: TyFileHandle,
+        diagnostic: TyDiagnostic,
+    ): TyCodeAction[] | undefined;
 }
 
 enum TySeverity {
@@ -68,23 +74,24 @@ export class TyServer {
             if (!(tyRange && rangesOverlap(toRange(tyRange), params.range))) {
                 continue;
             }
-            const action = diagnostic.codeAction(this.workspace);
-            if (!action) {
-                continue;
-            }
-            actions.push({
-                title: `${action.title} (ty)`,
-                kind: "quickfix",
-                isPreferred: action.preferred,
-                edit: {
-                    changes: {
-                        [uri]: action.edits.map((edit) => ({
-                            range: toRange(edit.range),
-                            newText: edit.new_text,
-                        })),
+            for (const action of this.workspace.codeActions(
+                handle,
+                diagnostic,
+            ) ?? []) {
+                actions.push({
+                    title: `${action.title} (ty)`,
+                    kind: "quickfix",
+                    isPreferred: action.preferred,
+                    edit: {
+                        changes: {
+                            [uri]: action.edits.map((edit) => ({
+                                range: toRange(edit.range),
+                                newText: edit.new_text,
+                            })),
+                        },
                     },
-                },
-            });
+                });
+            }
         }
         return actions;
     }
@@ -140,15 +147,4 @@ function toSeverity(severity: number): LSP.DiagnosticSeverity {
         default:
             return DiagnosticSeverity.Information;
     }
-}
-
-function rangesOverlap(a: LSP.Range, b: LSP.Range): boolean {
-    return !(isBefore(a.end, b.start) || isBefore(b.end, a.start));
-}
-
-function isBefore(a: LSP.Position, b: LSP.Position): boolean {
-    if (a.line !== b.line) {
-        return a.line < b.line;
-    }
-    return a.character < b.character;
 }

--- a/demo/python/worker.ts
+++ b/demo/python/worker.ts
@@ -15,7 +15,6 @@ const RUFF_CONFIG = {
     },
 };
 
-// Structural type for the (optional) ty_wasm module. See tyServer.ts.
 interface TyModule {
     default: (moduleOrPath?: unknown) => Promise<unknown>;
     Workspace: new (
@@ -31,12 +30,9 @@ interface PythonServers {
     ty: TyServer | null;
 }
 
-/**
- * Optionally load ty (Astral's type checker) from the vendored WASM build. The
- * artifact isn't published to npm; `import.meta.glob` resolves to an empty map
- * when demo/vendor/ty_wasm/ is absent, so the demo falls back to Ruff-only and
- * still builds without a Rust toolchain. Run `pnpm build:ty-wasm` to enable it.
- */
+// ty_wasm isn't published to npm. import.meta.glob resolves to an empty map when
+// demo/vendor/ty_wasm/ is absent, so the demo falls back to Ruff-only without a
+// Rust toolchain. Run `pnpm build:ty-wasm` to enable it.
 async function loadTy(): Promise<TyServer | null> {
     const modules = import.meta.glob("../vendor/ty_wasm/ty_wasm.js");
     const loader = modules["../vendor/ty_wasm/ty_wasm.js"];
@@ -54,8 +50,6 @@ async function loadTy(): Promise<TyServer | null> {
     }
 }
 
-// Load both engines once; handlers await this so messages that arrive during
-// initialization aren't dropped.
 const ready = (async (): Promise<PythonServers> => {
     await init();
     const ruff = new RuffServer(
@@ -66,7 +60,6 @@ const ready = (async (): Promise<PythonServers> => {
 })();
 
 function publish(servers: PythonServers, uri: string, text: string): void {
-    // Merge Ruff's lint diagnostics with ty's type-check diagnostics.
     const ruffParams = servers.ruff.setDocument(uri, text);
     const tyDiagnostics = servers.ty?.setDocument(uri, text) ?? [];
     publishDiagnostics({

--- a/demo/python/worker.ts
+++ b/demo/python/worker.ts
@@ -2,6 +2,7 @@ import init, { PositionEncoding, Workspace } from "@astral-sh/ruff-wasm-web";
 import type * as LSP from "vscode-languageserver-protocol";
 import { publishDiagnostics, serve } from "../shared/workerRpc";
 import { RuffServer } from "./ruffServer";
+import { TyServer, type TyWorkspace } from "./tyServer";
 
 const RUFF_CONFIG = {
     "line-length": 88,
@@ -14,36 +15,91 @@ const RUFF_CONFIG = {
     },
 };
 
-// Load the WASM module once; handlers below await this before doing any work so
-// messages that arrive during initialization aren't dropped.
-const ready = (async () => {
+// Structural type for the (optional) ty_wasm module. See tyServer.ts.
+interface TyModule {
+    default: (moduleOrPath?: unknown) => Promise<unknown>;
+    Workspace: new (
+        root: string,
+        positionEncoding: number,
+        options: unknown,
+    ) => TyWorkspace;
+    PositionEncoding: { Utf16: number };
+}
+
+interface PythonServers {
+    ruff: RuffServer;
+    ty: TyServer | null;
+}
+
+/**
+ * Optionally load ty (Astral's type checker) from the vendored WASM build. The
+ * artifact isn't published to npm; `import.meta.glob` resolves to an empty map
+ * when demo/vendor/ty_wasm/ is absent, so the demo falls back to Ruff-only and
+ * still builds without a Rust toolchain. Run `pnpm build:ty-wasm` to enable it.
+ */
+async function loadTy(): Promise<TyServer | null> {
+    const modules = import.meta.glob("../vendor/ty_wasm/ty_wasm.js");
+    const loader = modules["../vendor/ty_wasm/ty_wasm.js"];
+    if (!loader) {
+        return null;
+    }
+    try {
+        const ty = (await loader()) as unknown as TyModule;
+        await ty.default();
+        const workspace = new ty.Workspace("/", ty.PositionEncoding.Utf16, {});
+        return new TyServer(workspace);
+    } catch (error) {
+        console.error("Failed to load ty; continuing with Ruff only", error);
+        return null;
+    }
+}
+
+// Load both engines once; handlers await this so messages that arrive during
+// initialization aren't dropped.
+const ready = (async (): Promise<PythonServers> => {
     await init();
-    return new RuffServer(new Workspace(RUFF_CONFIG, PositionEncoding.Utf16));
+    const ruff = new RuffServer(
+        new Workspace(RUFF_CONFIG, PositionEncoding.Utf16),
+    );
+    const ty = await loadTy();
+    return { ruff, ty };
 })();
+
+function publish(servers: PythonServers, uri: string, text: string): void {
+    // Merge Ruff's lint diagnostics with ty's type-check diagnostics.
+    const ruffParams = servers.ruff.setDocument(uri, text);
+    const tyDiagnostics = servers.ty?.setDocument(uri, text) ?? [];
+    publishDiagnostics({
+        uri,
+        diagnostics: [...ruffParams.diagnostics, ...tyDiagnostics],
+    });
+}
 
 serve({
     requests: {
-        initialize: async () => (await ready).initializeResult(),
-        "textDocument/codeAction": async (params) =>
-            (await ready).codeAction(params as LSP.CodeActionParams),
+        initialize: async () => (await ready).ruff.initializeResult(),
+        "textDocument/codeAction": async (params) => {
+            const servers = await ready;
+            const codeActionParams = params as LSP.CodeActionParams;
+            return [
+                ...servers.ruff.codeAction(codeActionParams),
+                ...(servers.ty?.codeAction(codeActionParams) ?? []),
+            ];
+        },
     },
     notifications: {
         "textDocument/didOpen": async (params) => {
-            const server = await ready;
+            const servers = await ready;
             const { textDocument } = params as LSP.DidOpenTextDocumentParams;
-            publishDiagnostics(
-                server.setDocument(textDocument.uri, textDocument.text),
-            );
+            publish(servers, textDocument.uri, textDocument.text);
         },
         "textDocument/didChange": async (params) => {
-            const server = await ready;
+            const servers = await ready;
             const { textDocument, contentChanges } =
                 params as LSP.DidChangeTextDocumentParams;
             const change = contentChanges[0];
             if (change) {
-                publishDiagnostics(
-                    server.setDocument(textDocument.uri, change.text),
-                );
+                publish(servers, textDocument.uri, change.text);
             }
         },
     },

--- a/demo/shared/ranges.ts
+++ b/demo/shared/ranges.ts
@@ -1,0 +1,12 @@
+import type * as LSP from "vscode-languageserver-protocol";
+
+export function rangesOverlap(a: LSP.Range, b: LSP.Range): boolean {
+    return !(isBefore(a.end, b.start) || isBefore(b.end, a.start));
+}
+
+function isBefore(a: LSP.Position, b: LSP.Position): boolean {
+    if (a.line !== b.line) {
+        return a.line < b.line;
+    }
+    return a.character < b.character;
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "dev": "vite",
         "build": "tsc",
         "build:demo": "vite build",
+        "build:ty-wasm": "bash scripts/build-ty-wasm.sh",
         "lint": "biome check --write",
         "lint:ci": "biome check",
         "typecheck": "tsc --noEmit",

--- a/scripts/build-ty-wasm.sh
+++ b/scripts/build-ty-wasm.sh
@@ -37,4 +37,9 @@ fi
 echo "Building ty_wasm (this compiles a large Rust project; it can take a while)..."
 wasm-pack build "$RUFF_DIR/crates/ty_wasm" --target web --out-dir "$OUT_DIR"
 
+# wasm-pack drops a .gitignore ("*") in the out-dir; remove it so the artifact
+# is committable (GitHub Pages serves the vendored build).
+rm -f "$OUT_DIR/.gitignore"
+
 echo "Done. Vendored ty_wasm into $OUT_DIR"
+echo "Commit demo/vendor/ty_wasm/ so the live demo ships ty."

--- a/scripts/build-ty-wasm.sh
+++ b/scripts/build-ty-wasm.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#
+# Build the `ty` (Astral's Python type checker) WASM module and vendor it into
+# the demo so the Python tab can show type-check diagnostics alongside Ruff.
+#
+# `ty_wasm` is not published to npm, so we build it from the ruff monorepo with
+# wasm-pack (exactly like the ty playground does). The output lands in
+# demo/vendor/ty_wasm/ (gitignored by default). Without it, the Python demo
+# gracefully falls back to Ruff only.
+#
+# Requirements: Rust toolchain, wasm-pack, and git.
+#
+# Usage:
+#   pnpm build:ty-wasm
+#   RUFF_REPO=/path/to/ruff pnpm build:ty-wasm   # reuse an existing checkout
+#   RUFF_REF=main pnpm build:ty-wasm             # pin a branch/tag/commit
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT_DIR="$ROOT/demo/vendor/ty_wasm"
+RUFF_REF="${RUFF_REF:-main}"
+
+if ! command -v wasm-pack >/dev/null 2>&1; then
+    echo "error: wasm-pack not found. Install it: https://rustwasm.github.io/wasm-pack/installer/" >&2
+    exit 1
+fi
+
+# Use an existing ruff checkout if provided, otherwise clone into .cache.
+if [ -n "${RUFF_REPO:-}" ]; then
+    RUFF_DIR="$RUFF_REPO"
+else
+    RUFF_DIR="$ROOT/.cache/ruff"
+    if [ ! -d "$RUFF_DIR/.git" ]; then
+        echo "Cloning astral-sh/ruff into $RUFF_DIR ..."
+        mkdir -p "$ROOT/.cache"
+        git clone --filter=blob:none https://github.com/astral-sh/ruff "$RUFF_DIR"
+    fi
+    echo "Checking out ruff@$RUFF_REF ..."
+    git -C "$RUFF_DIR" fetch --quiet origin "$RUFF_REF"
+    git -C "$RUFF_DIR" checkout --quiet "$RUFF_REF"
+    git -C "$RUFF_DIR" pull --quiet --ff-only origin "$RUFF_REF" || true
+fi
+
+echo "Building ty_wasm (this compiles a large Rust project; it can take a while)..."
+wasm-pack build "$RUFF_DIR/crates/ty_wasm" --target web --out-dir "$OUT_DIR"
+
+echo "Done. Vendored ty_wasm into $OUT_DIR"

--- a/scripts/build-ty-wasm.sh
+++ b/scripts/build-ty-wasm.sh
@@ -29,9 +29,11 @@ else
         git clone --filter=blob:none https://github.com/astral-sh/ruff "$RUFF_DIR"
     fi
     echo "Checking out ruff@$RUFF_REF ..."
+    # Fetch and hard-reset to the exact fetched commit so the built artifact
+    # always matches RUFF_REF (fails loudly via `set -e` if the fetch fails,
+    # rather than silently building a stale or locally-modified revision).
     git -C "$RUFF_DIR" fetch --quiet origin "$RUFF_REF"
-    git -C "$RUFF_DIR" checkout --quiet "$RUFF_REF"
-    git -C "$RUFF_DIR" pull --quiet --ff-only origin "$RUFF_REF" || true
+    git -C "$RUFF_DIR" checkout --quiet --force --detach FETCH_HEAD
 fi
 
 echo "Building ty_wasm (this compiles a large Rust project; it can take a while)..."

--- a/scripts/build-ty-wasm.sh
+++ b/scripts/build-ty-wasm.sh
@@ -1,14 +1,7 @@
 #!/usr/bin/env bash
 #
-# Build the `ty` (Astral's Python type checker) WASM module and vendor it into
-# the demo so the Python tab can show type-check diagnostics alongside Ruff.
-#
-# `ty_wasm` is not published to npm, so we build it from the ruff monorepo with
-# wasm-pack (exactly like the ty playground does). The output lands in
-# demo/vendor/ty_wasm/ (gitignored by default). Without it, the Python demo
-# gracefully falls back to Ruff only.
-#
-# Requirements: Rust toolchain, wasm-pack, and git.
+# Build ty_wasm from the ruff monorepo and vendor it into demo/vendor/ty_wasm/.
+# Requires a Rust toolchain, wasm-pack, and git.
 #
 # Usage:
 #   pnpm build:ty-wasm


### PR DESCRIPTION
Runs Ruff and `ty` (Astral's type checker) together in the Python demo tab: the worker merges Ruff's lint diagnostics + fixes + formatting with ty's type-check diagnostics + fixes in the same document.

Since `ty_wasm` isn't published to npm, it's loaded optionally via `import.meta.glob` from `demo/vendor/ty_wasm/`. When the artifact isn't present the demo falls back to Ruff only — no Rust toolchain needed to build or run the demo.

- `demo/python/tyServer.ts` — maps ty `Diagnostic`/`CodeAction` to LSP shapes (ty positions are 1-indexed; LSP is 0-indexed).
- `demo/python/worker.ts` — optional ty loader; `publishDiagnostics` sends `ruff ++ ty`, and code actions concatenate both.
- `scripts/build-ty-wasm.sh` + `pnpm build:ty-wasm` — `wasm-pack build crates/ty_wasm --target web` into `demo/vendor/ty_wasm/` (gitignored, like the ty playground). README documents it.
- Sample gains a type error so ty's diagnostic is visible once built.

**Verified here (Ruff-only path, no artifact):** `lint:ci` clean, `build:demo` succeeds with the glob resolving to nothing, the Python tab still shows F401 diagnostics + all code actions with no console errors, and the 294-test suite passes.

**Not verified here:** the ty half — this environment has no Rust toolchain, so I couldn't build `ty_wasm` to exercise it. The mapping is written against the crate's `wasm_bindgen` API; please run `pnpm build:ty-wasm` and confirm ty diagnostics appear before relying on it. There's a chance of small adjustments (e.g. `Workspace` options or wasm-bindgen field-name casing) once it can be run.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add optional `ty` type-checking to the Python demo. The worker runs Ruff (lint + format) and, when vendored, `ty_wasm`, merging diagnostics and quick-fixes; the live demo can ship `ty` by committing the vendor build, and it falls back to Ruff-only when absent.

- **New Features**
  - Python worker optionally loads vendored `ty_wasm` via `import.meta.glob` and merges Ruff lint output with `ty` type-check diagnostics and code actions; Ruff handles formatting.
  - `TyServer` maps `ty` diagnostics/code actions to LSP (converts 1-indexed positions) and uses `Workspace.codeActions` to include workspace-derived fixes (e.g. import suggestions).
  - Vendored `ty_wasm` can be committed for GitHub Pages: `.gitattributes` marks it generated/binary; `pnpm build:ty-wasm` builds it and strips wasm-pack’s `.gitignore`.

- **Refactors**
  - Extracted `rangesOverlap` to `demo/shared/ranges.ts`, shared by Ruff and `ty` servers.
  - `scripts/build-ty-wasm.sh` hard-resets the cached `ruff` checkout to the fetched ref for consistent builds.

<sup>Written for commit 7fa4fe087d7f31ab8a7eb52e8acd172f8693b419. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marimo-team/codemirror-languageserver/pull/76?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

