### PR TITLE
feat: document lifecycle — didOpen/didClose ref-counting & save notifications

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -476,6 +476,7 @@ describe("exports", () => {
             "LanguageServerClient",
             "LanguageServerPlugin",
             "documentUri",
+            "getLanguageServerPlugin",
             "languageId",
             "languageServer",
             "languageServerWithClient",

--- a/src/__tests__/language-server-client.test.ts
+++ b/src/__tests__/language-server-client.test.ts
@@ -309,9 +309,9 @@ describe("LanguageServerClient", () => {
 
             expect(caps.textDocument.synchronization).toEqual({
                 dynamicRegistration: true,
-                willSave: false,
-                didSave: false,
-                willSaveWaitUntil: false,
+                willSave: true,
+                didSave: true,
+                willSaveWaitUntil: true,
             });
 
             expect(caps.textDocument.completion).toEqual({

--- a/src/__tests__/lsp-robustness.test.ts
+++ b/src/__tests__/lsp-robustness.test.ts
@@ -256,3 +256,72 @@ describe("textDocumentDidClose", () => {
         });
     });
 });
+
+describe("document open ref-counting", () => {
+    function openParams(uri: string) {
+        return {
+            textDocument: {
+                uri,
+                languageId: "plaintext",
+                text: "",
+                version: 0,
+            },
+        };
+    }
+
+    function countNotifications(
+        // biome-ignore lint/suspicious/noExplicitAny: inspecting mock args
+        internal: any,
+        method: string,
+    ) {
+        return internal.notify.mock.calls.filter(
+            // biome-ignore lint/suspicious/noExplicitAny: inspecting mock args
+            (call: any[]) => call[0]?.method === method,
+        ).length;
+    }
+
+    it("sends didOpen only once when the same URI is opened twice", async () => {
+        const client = new LanguageServerClient(baseOptions());
+        const internal = clientInstances.at(-1);
+
+        await client.textDocumentDidOpen(openParams("file:///dup"));
+        await client.textDocumentDidOpen(openParams("file:///dup"));
+
+        expect(countNotifications(internal, "textDocument/didOpen")).toBe(1);
+    });
+
+    it("sends didClose only when the last view closes", async () => {
+        const client = new LanguageServerClient(baseOptions());
+        const internal = clientInstances.at(-1);
+
+        await client.textDocumentDidOpen(openParams("file:///dup"));
+        await client.textDocumentDidOpen(openParams("file:///dup"));
+
+        // First close just drops a reference; server is not notified yet.
+        await client.textDocumentDidClose({
+            textDocument: { uri: "file:///dup" },
+        });
+        expect(countNotifications(internal, "textDocument/didClose")).toBe(0);
+
+        // Second close is the last reference and does notify.
+        await client.textDocumentDidClose({
+            textDocument: { uri: "file:///dup" },
+        });
+        expect(countNotifications(internal, "textDocument/didClose")).toBe(1);
+    });
+
+    it("tracks distinct URIs independently", async () => {
+        const client = new LanguageServerClient(baseOptions());
+        const internal = clientInstances.at(-1);
+
+        await client.textDocumentDidOpen(openParams("file:///a"));
+        await client.textDocumentDidOpen(openParams("file:///b"));
+
+        expect(countNotifications(internal, "textDocument/didOpen")).toBe(2);
+
+        await client.textDocumentDidClose({
+            textDocument: { uri: "file:///a" },
+        });
+        expect(countNotifications(internal, "textDocument/didClose")).toBe(1);
+    });
+});

--- a/src/__tests__/plugin-behavior.test.ts
+++ b/src/__tests__/plugin-behavior.test.ts
@@ -36,6 +36,9 @@ function createFakeClient(overrides: FakeClientOverrides = {}) {
         textDocumentDidOpen: vi.fn().mockResolvedValue(undefined),
         textDocumentDidChange: vi.fn().mockResolvedValue(undefined),
         textDocumentDidClose: vi.fn().mockResolvedValue(undefined),
+        textDocumentWillSave: vi.fn().mockResolvedValue(undefined),
+        textDocumentWillSaveWaitUntil: vi.fn().mockResolvedValue(null),
+        textDocumentDidSave: vi.fn().mockResolvedValue(undefined),
         textDocumentCodeAction: vi.fn().mockResolvedValue(null),
         textDocumentPrepareRename: vi.fn(),
         textDocumentRename: vi.fn(),
@@ -167,6 +170,81 @@ describe("destroy lifecycle", () => {
         await pending;
 
         expect(dispatchSpy).not.toHaveBeenCalled();
+    });
+});
+
+describe("documentDidSave", () => {
+    it("runs the willSave -> willSaveWaitUntil -> didSave handshake per capabilities", async () => {
+        const client = createFakeClient({
+            capabilities: {
+                textDocumentSync: {
+                    willSave: true,
+                    willSaveWaitUntil: true,
+                    save: { includeText: true },
+                },
+            },
+        });
+        // Return an edit that inserts "!" at the end from willSaveWaitUntil
+        (
+            client.textDocumentWillSaveWaitUntil as ReturnType<typeof vi.fn>
+        ).mockResolvedValue([
+            {
+                range: {
+                    start: { line: 0, character: 5 },
+                    end: { line: 0, character: 5 },
+                },
+                newText: "!",
+            },
+        ]);
+        const view = createView("hello");
+        const plugin = createPlugin(view, client);
+        await flushTicks();
+
+        await plugin.documentDidSave();
+
+        expect(client.textDocumentWillSave).toHaveBeenCalledWith({
+            textDocument: { uri: "file:///test.ts" },
+            reason: 1,
+        });
+        expect(client.textDocumentWillSaveWaitUntil).toHaveBeenCalled();
+        // The willSaveWaitUntil edit was applied before didSave
+        expect(view.state.doc.toString()).toBe("hello!");
+        // includeText is set, so didSave carries the post-edit text
+        expect(client.textDocumentDidSave).toHaveBeenCalledWith({
+            textDocument: { uri: "file:///test.ts" },
+            text: "hello!",
+        });
+    });
+
+    it("skips willSave and didSave when the server did not register for them", async () => {
+        const client = createFakeClient({
+            capabilities: { textDocumentSync: 1 },
+        });
+        const view = createView("hello");
+        const plugin = createPlugin(view, client);
+        await flushTicks();
+
+        await plugin.documentDidSave();
+
+        expect(client.textDocumentWillSave).not.toHaveBeenCalled();
+        expect(client.textDocumentWillSaveWaitUntil).not.toHaveBeenCalled();
+        expect(client.textDocumentDidSave).not.toHaveBeenCalled();
+    });
+
+    it("sends didSave without text when includeText is not set", async () => {
+        const client = createFakeClient({
+            capabilities: { textDocumentSync: { save: true } },
+        });
+        const view = createView("hello");
+        const plugin = createPlugin(view, client);
+        await flushTicks();
+
+        await plugin.documentDidSave();
+
+        expect(client.textDocumentDidSave).toHaveBeenCalledWith({
+            textDocument: { uri: "file:///test.ts" },
+            text: undefined,
+        });
     });
 });
 

--- a/src/__tests__/plugin-behavior.test.ts
+++ b/src/__tests__/plugin-behavior.test.ts
@@ -148,6 +148,34 @@ describe("destroy lifecycle", () => {
         expect(client.textDocumentDidClose).not.toHaveBeenCalled();
     });
 
+    it("closes the document if destroyed while didOpen is in flight", async () => {
+        let resolveOpen: () => void = () => {};
+        const client = createFakeClient();
+        (
+            client.textDocumentDidOpen as ReturnType<typeof vi.fn>
+        ).mockReturnValue(
+            new Promise<void>((resolve) => {
+                resolveOpen = resolve;
+            }),
+        );
+        const view = createView("hello");
+        const plugin = createPlugin(view, client);
+        // Let initialize get past initializePromise and issue didOpen, which is
+        // still pending.
+        await flushTicks();
+
+        // Tear down while didOpen has not resolved yet.
+        plugin.destroy();
+        // didOpen resolves after destroy; the plugin must still close.
+        resolveOpen();
+        await flushTicks();
+
+        expect(client.textDocumentDidOpen).toHaveBeenCalled();
+        expect(client.textDocumentDidClose).toHaveBeenCalledWith({
+            textDocument: { uri: "file:///test.ts" },
+        });
+    });
+
     it("does not dispatch diagnostics after destroy", async () => {
         const client = createFakeClient();
         const view = createView("hello");
@@ -206,7 +234,10 @@ describe("documentDidSave", () => {
             textDocument: { uri: "file:///test.ts" },
             reason: 1,
         });
-        expect(client.textDocumentWillSaveWaitUntil).toHaveBeenCalled();
+        expect(client.textDocumentWillSaveWaitUntil).toHaveBeenCalledWith({
+            textDocument: { uri: "file:///test.ts" },
+            reason: 1,
+        });
         // The willSaveWaitUntil edit was applied before didSave
         expect(view.state.doc.toString()).toBe("hello!");
         // includeText is set, so didSave carries the post-edit text
@@ -228,6 +259,37 @@ describe("documentDidSave", () => {
 
         expect(client.textDocumentWillSave).not.toHaveBeenCalled();
         expect(client.textDocumentWillSaveWaitUntil).not.toHaveBeenCalled();
+        expect(client.textDocumentDidSave).not.toHaveBeenCalled();
+    });
+
+    it("does not send didSave when destroyed mid-handshake", async () => {
+        let resolveWillSave: () => void = () => {};
+        const client = createFakeClient({
+            capabilities: {
+                textDocumentSync: { willSave: true, save: true },
+            },
+        });
+        (
+            client.textDocumentWillSave as ReturnType<typeof vi.fn>
+        ).mockReturnValue(
+            new Promise<void>((resolve) => {
+                resolveWillSave = resolve;
+            }),
+        );
+        const view = createView("hello");
+        const plugin = createPlugin(view, client);
+        await flushTicks();
+
+        const savePromise = plugin.documentDidSave();
+        // Let the handshake reach willSave (now in flight) before tearing down.
+        await flushTicks();
+        expect(client.textDocumentWillSave).toHaveBeenCalled();
+
+        plugin.destroy();
+        resolveWillSave();
+        await savePromise;
+
+        // The post-willSave lifecycle guard must stop the handshake here.
         expect(client.textDocumentDidSave).not.toHaveBeenCalled();
     });
 

--- a/src/__tests__/plugin-behavior.test.ts
+++ b/src/__tests__/plugin-behavior.test.ts
@@ -4,7 +4,7 @@ import { EditorView } from "@codemirror/view";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type * as LSP from "vscode-languageserver-protocol";
 import type { FeatureOptions, LanguageServerClient } from "../lsp.js";
-import { LanguageServerPlugin } from "../plugin.js";
+import { LanguageServerPlugin, getLanguageServerPlugin } from "../plugin.js";
 
 const featureOptions: Required<FeatureOptions> = {
     diagnosticsEnabled: true,
@@ -198,6 +198,28 @@ describe("destroy lifecycle", () => {
         await pending;
 
         expect(dispatchSpy).not.toHaveBeenCalled();
+    });
+});
+
+describe("getLanguageServerPlugin", () => {
+    it("exposes the plugin attached to a view", () => {
+        const view = createView("hello");
+        const plugin = createPlugin(view);
+        expect(getLanguageServerPlugin(view)).toBe(plugin);
+    });
+
+    it("keeps exposing an earlier plugin after a later one is destroyed", () => {
+        const view = createView("hello");
+        const first = createPlugin(view);
+        const second = createPlugin(view);
+        expect(getLanguageServerPlugin(view)).toBe(second);
+
+        second.destroy();
+        // The still-active earlier plugin must remain reachable.
+        expect(getLanguageServerPlugin(view)).toBe(first);
+
+        first.destroy();
+        expect(getLanguageServerPlugin(view)).toBeUndefined();
     });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export {
     LanguageServerPlugin,
+    getLanguageServerPlugin,
     languageServerWithClient,
     languageServer,
     signatureHelpTooltipField,

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -36,6 +36,10 @@ export interface LSPRequestMap {
         LSP.SignatureHelpParams,
         LSP.SignatureHelp | null,
     ];
+    "textDocument/willSaveWaitUntil": [
+        LSP.WillSaveTextDocumentParams,
+        LSP.TextEdit[] | null,
+    ];
 }
 
 // Client to server
@@ -44,6 +48,8 @@ export interface LSPNotifyMap {
     "textDocument/didChange": LSP.DidChangeTextDocumentParams;
     "textDocument/didOpen": LSP.DidOpenTextDocumentParams;
     "textDocument/didClose": LSP.DidCloseTextDocumentParams;
+    "textDocument/willSave": LSP.WillSaveTextDocumentParams;
+    "textDocument/didSave": LSP.DidSaveTextDocumentParams;
 }
 
 // Server to client
@@ -212,6 +218,13 @@ export class LanguageServerClient {
     public clientCapabilities: LanguageServerClientOptions["capabilities"];
 
     private notificationListeners: Set<(n: Notification) => void> = new Set();
+    /**
+     * How many open editors (plugins) hold each document URI. Several views
+     * may share one client and one URI (e.g. split views); the server should
+     * see a single didOpen/didClose pair, so we only notify on the 0->1 and
+     * 1->0 transitions.
+     */
+    private documentOpenCounts = new Map<string, number>();
     private webSocketConnection?: WebSocketTransport["connection"];
     private webSocketMessageHandler?: (message: { data: unknown }) => void;
     private isClosed = false;
@@ -309,9 +322,9 @@ export class LanguageServerClient {
                 moniker: {},
                 synchronization: {
                     dynamicRegistration: true,
-                    willSave: false,
-                    didSave: false,
-                    willSaveWaitUntil: false,
+                    willSave: true,
+                    didSave: true,
+                    willSaveWaitUntil: true,
                 },
                 codeAction: {
                     dynamicRegistration: true,
@@ -426,6 +439,14 @@ export class LanguageServerClient {
     }
 
     public textDocumentDidOpen(params: LSP.DidOpenTextDocumentParams) {
+        const uri = params.textDocument.uri;
+        const previous = this.documentOpenCounts.get(uri) ?? 0;
+        this.documentOpenCounts.set(uri, previous + 1);
+        // Additional views onto an already-open document share the server's
+        // single open; only the first view sends didOpen.
+        if (previous > 0) {
+            return Promise.resolve(undefined);
+        }
         return this.notify("textDocument/didOpen", params);
     }
 
@@ -434,7 +455,35 @@ export class LanguageServerClient {
     }
 
     public textDocumentDidClose(params: LSP.DidCloseTextDocumentParams) {
+        const uri = params.textDocument.uri;
+        const previous = this.documentOpenCounts.get(uri) ?? 0;
+        // Only the last view closing the document notifies the server; earlier
+        // closes just drop a reference. A close with no tracked open (previous
+        // <= 1) still notifies, so direct callers are not silently swallowed.
+        if (previous > 1) {
+            this.documentOpenCounts.set(uri, previous - 1);
+            return Promise.resolve(undefined);
+        }
+        this.documentOpenCounts.delete(uri);
         return this.notify("textDocument/didClose", params);
+    }
+
+    public textDocumentWillSave(params: LSP.WillSaveTextDocumentParams) {
+        return this.notify("textDocument/willSave", params);
+    }
+
+    public async textDocumentWillSaveWaitUntil(
+        params: LSP.WillSaveTextDocumentParams,
+    ) {
+        return await this.request(
+            "textDocument/willSaveWaitUntil",
+            params,
+            this.timeout,
+        );
+    }
+
+    public textDocumentDidSave(params: LSP.DidSaveTextDocumentParams) {
+        return this.notify("textDocument/didSave", params);
     }
 
     public async textDocumentHover(params: LSP.HoverParams) {

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -223,6 +223,10 @@ export class LanguageServerClient {
      * may share one client and one URI (e.g. split views); the server should
      * see a single didOpen/didClose pair, so we only notify on the 0->1 and
      * 1->0 transitions.
+     *
+     * Note: this coalesces open/close only. didChange notifications and
+     * document versions remain per-plugin, so concurrently editing the same
+     * URI from multiple views is not fully synchronized.
      */
     private documentOpenCounts = new Map<string, number>();
     private webSocketConnection?: WebSocketTransport["connection"];

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -17,6 +17,7 @@ import { WebSocketTransport } from "@open-rpc/client-js";
 import {
     CompletionTriggerKind,
     DiagnosticSeverity,
+    TextDocumentSaveReason,
     TextDocumentSyncKind,
 } from "vscode-languageserver-protocol";
 
@@ -296,6 +297,69 @@ export class LanguageServerPlugin implements PluginValue {
             });
         } catch (e) {
             console.error(e);
+        }
+    }
+
+    /**
+     * Notifies the language server that the document was (or is about to be)
+     * saved. The library has no concept of "save" on its own, so hosts wire
+     * this to their own save action.
+     *
+     * Follows the LSP save handshake, honoring the server's advertised
+     * capabilities: willSave -> willSaveWaitUntil (applying returned edits) ->
+     * didSave (including the document text when the server requested it).
+     */
+    public async documentDidSave(
+        reason: LSP.TextDocumentSaveReason = TextDocumentSaveReason.Manual,
+    ) {
+        if (!this.client.ready) {
+            return;
+        }
+
+        const sync = this.client.capabilities?.textDocumentSync;
+        // Save-related sub-capabilities only exist on the object form; a plain
+        // sync-kind number carries no save information.
+        const syncOptions =
+            typeof sync === "object" && sync != null ? sync : undefined;
+
+        if (syncOptions?.willSave) {
+            try {
+                await this.client.textDocumentWillSave({
+                    textDocument: { uri: this.documentUri },
+                    reason,
+                });
+            } catch (error) {
+                console.error("Failed to send willSave", error);
+            }
+        }
+
+        if (syncOptions?.willSaveWaitUntil) {
+            try {
+                const edits = await this.client.textDocumentWillSaveWaitUntil({
+                    textDocument: { uri: this.documentUri },
+                    reason,
+                });
+                if (edits && edits.length > 0 && !this.destroyed) {
+                    this.applyEdits(this.view, edits);
+                }
+            } catch (error) {
+                console.error("Failed during willSaveWaitUntil", error);
+            }
+        }
+
+        // Only send didSave if the server registered for it.
+        const save = syncOptions?.save;
+        if (save == null || save === false) {
+            return;
+        }
+        const includeText = typeof save === "object" && save.includeText;
+        try {
+            await this.client.textDocumentDidSave({
+                textDocument: { uri: this.documentUri },
+                text: includeText ? this.view.state.doc.toString() : undefined,
+            });
+        } catch (error) {
+            console.error("Failed to send didSave", error);
         }
     }
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -99,21 +99,47 @@ export const suppressSignatureHelp = Annotation.define<boolean>();
 const SIGNATURE_TOOLTIP_MAX_LINES_BACK = 20;
 
 /**
- * Maps each editor view to its active language server plugin so hosts can
- * reach plugin methods (e.g. `documentDidSave`) without the private
- * `ViewPlugin` token. If several language servers attach to one view, the
- * most recently constructed plugin wins.
+ * Maps each editor view to the language server plugins attached to it so
+ * hosts can reach plugin methods (e.g. `documentDidSave`) without the private
+ * `ViewPlugin` token. Several language servers may attach to one view; the
+ * list keeps every live plugin so destroying one still exposes the others.
  */
-const pluginRegistry = new WeakMap<EditorView, LanguageServerPlugin>();
+const pluginRegistry = new WeakMap<EditorView, LanguageServerPlugin[]>();
+
+function registerPlugin(view: EditorView, plugin: LanguageServerPlugin) {
+    const plugins = pluginRegistry.get(view);
+    if (plugins) {
+        plugins.push(plugin);
+    } else {
+        pluginRegistry.set(view, [plugin]);
+    }
+}
+
+function unregisterPlugin(view: EditorView, plugin: LanguageServerPlugin) {
+    const plugins = pluginRegistry.get(view);
+    if (!plugins) {
+        return;
+    }
+    const index = plugins.indexOf(plugin);
+    if (index !== -1) {
+        plugins.splice(index, 1);
+    }
+    if (plugins.length === 0) {
+        pluginRegistry.delete(view);
+    }
+}
 
 /**
  * Returns the language server plugin attached to a view, if any. Useful for
  * invoking host-driven actions such as {@link LanguageServerPlugin.documentDidSave}.
+ * When multiple servers share a view, the most recently attached live plugin
+ * is returned.
  */
 export function getLanguageServerPlugin(
     view: EditorView,
 ): LanguageServerPlugin | undefined {
-    return pluginRegistry.get(view);
+    const plugins = pluginRegistry.get(view);
+    return plugins?.[plugins.length - 1];
 }
 
 export class LanguageServerPlugin implements PluginValue {
@@ -200,7 +226,7 @@ export class LanguageServerPlugin implements PluginValue {
         this.featureOptions = featureOptions;
         this.onGoToDefinition = onGoToDefinition;
         this.markdownRenderer = markdownRenderer;
-        pluginRegistry.set(view, this);
+        registerPlugin(view, this);
         this.disposeListener = client.onNotification(
             this.processNotification.bind(this),
         );
@@ -246,9 +272,7 @@ export class LanguageServerPlugin implements PluginValue {
         this.destroyed = true;
         this.disposeListener?.();
         this.disposeListener = undefined;
-        if (pluginRegistry.get(this.view) === this) {
-            pluginRegistry.delete(this.view);
-        }
+        unregisterPlugin(this.view, this);
         this.closeDocument();
     }
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -98,6 +98,24 @@ export const suppressSignatureHelp = Annotation.define<boolean>();
 
 const SIGNATURE_TOOLTIP_MAX_LINES_BACK = 20;
 
+/**
+ * Maps each editor view to its active language server plugin so hosts can
+ * reach plugin methods (e.g. `documentDidSave`) without the private
+ * `ViewPlugin` token. If several language servers attach to one view, the
+ * most recently constructed plugin wins.
+ */
+const pluginRegistry = new WeakMap<EditorView, LanguageServerPlugin>();
+
+/**
+ * Returns the language server plugin attached to a view, if any. Useful for
+ * invoking host-driven actions such as {@link LanguageServerPlugin.documentDidSave}.
+ */
+export function getLanguageServerPlugin(
+    view: EditorView,
+): LanguageServerPlugin | undefined {
+    return pluginRegistry.get(view);
+}
+
 export class LanguageServerPlugin implements PluginValue {
     private documentVersion: number;
     private pluginId: string;
@@ -182,6 +200,7 @@ export class LanguageServerPlugin implements PluginValue {
         this.featureOptions = featureOptions;
         this.onGoToDefinition = onGoToDefinition;
         this.markdownRenderer = markdownRenderer;
+        pluginRegistry.set(view, this);
         this.disposeListener = client.onNotification(
             this.processNotification.bind(this),
         );
@@ -227,17 +246,31 @@ export class LanguageServerPlugin implements PluginValue {
         this.destroyed = true;
         this.disposeListener?.();
         this.disposeListener = undefined;
+        if (pluginRegistry.get(this.view) === this) {
+            pluginRegistry.delete(this.view);
+        }
+        this.closeDocument();
+    }
+
+    /**
+     * Sends `textDocument/didClose` for a document this plugin opened,
+     * releasing its reference on the shared client's open-count. Safe to call
+     * more than once and before the document was opened.
+     */
+    private closeDocument() {
         // Only close a document we actually opened - a view torn down during
         // its initial async tick may never have sent didOpen
-        if (this.documentOpened && this.client.ready) {
-            Promise.resolve(
-                this.client.textDocumentDidClose({
-                    textDocument: { uri: this.documentUri },
-                }),
-            ).catch((error) => {
-                console.error("Failed to send didClose", error);
-            });
+        if (!(this.documentOpened && this.client.ready)) {
+            return;
         }
+        this.documentOpened = false;
+        Promise.resolve(
+            this.client.textDocumentDidClose({
+                textDocument: { uri: this.documentUri },
+            }),
+        ).catch((error) => {
+            console.error("Failed to send didClose", error);
+        });
     }
 
     public async initialize({ documentText }: { documentText?: string } = {}) {
@@ -258,6 +291,12 @@ export class LanguageServerPlugin implements PluginValue {
             },
         });
         this.documentOpened = true;
+        // If the view was torn down while didOpen was in flight, destroy() saw
+        // documentOpened === false and could not close. Balance the open here
+        // so we neither leak the server-side document nor the open ref-count.
+        if (this.destroyed) {
+            this.closeDocument();
+        }
     }
 
     /**
@@ -316,6 +355,13 @@ export class LanguageServerPlugin implements PluginValue {
             return;
         }
 
+        // The save must observe all preceding document updates, otherwise the
+        // server may run the save against stale content.
+        await Promise.all(this.pendingDocumentChanges);
+        if (this.destroyed || !this.client.ready) {
+            return;
+        }
+
         const sync = this.client.capabilities?.textDocumentSync;
         // Save-related sub-capabilities only exist on the object form; a plain
         // sync-kind number carries no save information.
@@ -331,6 +377,9 @@ export class LanguageServerPlugin implements PluginValue {
             } catch (error) {
                 console.error("Failed to send willSave", error);
             }
+            if (this.destroyed || !this.client.ready) {
+                return;
+            }
         }
 
         if (syncOptions?.willSaveWaitUntil) {
@@ -341,9 +390,15 @@ export class LanguageServerPlugin implements PluginValue {
                 });
                 if (edits && edits.length > 0 && !this.destroyed) {
                     this.applyEdits(this.view, edits);
+                    // The applied edits queue their own didChange; make sure
+                    // the server sees them before we announce didSave.
+                    await Promise.all(this.pendingDocumentChanges);
                 }
             } catch (error) {
                 console.error("Failed during willSaveWaitUntil", error);
+            }
+            if (this.destroyed || !this.client.ready) {
+                return;
             }
         }
 


### PR DESCRIPTION
## Summary

Implements the document-lifecycle plan (`textDocument/didClose` & save notifications). The basic `didClose` on `destroy()` already existed; this PR adds the two missing pieces.

### 1. didOpen/didClose ref-counting (required)
Previously each plugin tracked its own `documentOpened` flag, so two views sharing one URI **and** one `LanguageServerClient` (e.g. split views) would send `didOpen` twice and fire `didClose` prematurely when the first view was torn down.

- `LanguageServerClient` now keeps a `Map<uri, number>` open-count.
- `textDocumentDidOpen` increments and only notifies the server on the `0→1` transition.
- `textDocumentDidClose` decrements and only notifies on the `1→0` transition (a direct close with no tracked open still notifies, preserving existing behavior).

### 2. Save notifications (optional section of the plan)
- Added `textDocument/willSave` + `textDocument/didSave` notifications and `textDocument/willSaveWaitUntil` request to the LSP maps and client.
- New public `LanguageServerPlugin.documentDidSave(reason?)` runs the LSP save handshake honoring server capabilities: `willSave` → `willSaveWaitUntil` (applies returned edits) → `didSave` (includes text only when `save.includeText` is set). No keybinding — hosts wire it to their own save action.
- Flipped the advertised `synchronization.willSave/didSave/willSaveWaitUntil` client capabilities to `true` now that they're implemented.

## Testing
- `lsp-robustness.test.ts`: ref-counting coverage (dup open → one `didOpen`; first close → none, last close → one `didClose`; distinct URIs tracked independently).
- `plugin-behavior.test.ts`: `documentDidSave` handshake tests (full flow with edit application + `includeText`; skip when server didn't register; `didSave` without text).
- `language-server-client.test.ts`: updated capability assertion to the new `true` values.

All checks pass: `typecheck`, `lint:ci` (clean), and **357 tests**.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements LSP document lifecycle: ref-counted `didOpen`/`didClose` and a robust save handshake (`willSave` → `willSaveWaitUntil` → `didSave`). Also exposes `getLanguageServerPlugin(view)` so hosts can trigger saves and handles multiple plugins per view.

- **Bug Fixes**
  - Tracks open counts per URI and only notifies on 0→1 and 1→0; a close without a tracked open still notifies. Open-count coalescing only affects open/close; per-view `didChange` remains independent.
  - Hardens teardown: balances an in-flight `didOpen` on destroy, awaits pending `didChange` before save and after applying `willSaveWaitUntil` edits to avoid stale saves, and guards each save phase so `didSave` never fires after `didClose`.
  - Maintains a per-view plugin registry so destroying a newer plugin doesn’t hide earlier ones; `getLanguageServerPlugin(view)` returns the most recently attached live plugin.

- **New Features**
  - Adds `textDocument/willSave`, `textDocument/willSaveWaitUntil`, and `textDocument/didSave`, plus `LanguageServerPlugin.documentDidSave(reason?)` to run the handshake and apply returned edits; includes text only when requested.
  - Exports `getLanguageServerPlugin(view)` for hosts to reach `documentDidSave`, and advertises `textDocument.synchronization.willSave`, `didSave`, and `willSaveWaitUntil` as true.

<sup>Written for commit 2bdf64d652864efa79d034ae02c901a2fe265e61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marimo-team/codemirror-languageserver/pull/77?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

