### PR TITLE
feat: proper server->client request handling (transport-agnostic dispatcher)

### DIFF
--- a/src/__tests__/explicitCompletion.test.ts
+++ b/src/__tests__/explicitCompletion.test.ts
@@ -7,7 +7,7 @@ import { EditorState, Transaction } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import { describe, expect, it, vi } from "vitest";
 import { CompletionTriggerKind } from "vscode-languageserver-protocol";
-import type { LanguageServerClient } from "../lsp.js";
+import { LanguageServerClient } from "../lsp.js";
 import { languageServerWithClient } from "../plugin.js";
 
 describe("completion request ordering", () => {
@@ -25,6 +25,8 @@ describe("completion request ordering", () => {
         const client = {
             ready: true,
             capabilities: { completionProvider: {} },
+            dynamicCapabilities: new Map(),
+            hasCapability: LanguageServerClient.prototype.hasCapability,
             initializePromise: Promise.resolve(),
             onNotification: vi.fn().mockReturnValue(() => {}),
             textDocumentDidOpen: vi.fn().mockResolvedValue(undefined),

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -31,6 +31,8 @@ const createMockClient = (
     const mockClient = {
         ready: true,
         capabilities: { definitionProvider: true },
+        dynamicCapabilities: new Map(),
+        hasCapability: LanguageServerClient.prototype.hasCapability,
         clientCapabilities: {},
         initializePromise: Promise.resolve(),
         initialize: vi.fn().mockResolvedValue(undefined),

--- a/src/__tests__/language-server-client.test.ts
+++ b/src/__tests__/language-server-client.test.ts
@@ -308,14 +308,14 @@ describe("LanguageServerClient", () => {
             });
 
             expect(caps.textDocument.synchronization).toEqual({
-                dynamicRegistration: true,
+                dynamicRegistration: false,
                 willSave: true,
                 didSave: true,
                 willSaveWaitUntil: true,
             });
 
             expect(caps.textDocument.completion).toEqual({
-                dynamicRegistration: true,
+                dynamicRegistration: false,
                 completionItem: {
                     snippetSupport: true,
                     commitCharactersSupport: true,
@@ -348,7 +348,7 @@ describe("LanguageServerClient", () => {
             });
 
             expect(caps.textDocument.signatureHelp).toEqual({
-                dynamicRegistration: true,
+                dynamicRegistration: false,
                 signatureInformation: {
                     documentationFormat: ["markdown", "plaintext"],
                 },
@@ -366,7 +366,7 @@ describe("LanguageServerClient", () => {
 
             // Test workspace capabilities
             expect(caps.workspace.didChangeConfiguration).toEqual({
-                dynamicRegistration: true,
+                dynamicRegistration: false,
             });
         });
     });

--- a/src/__tests__/lsp-robustness.test.ts
+++ b/src/__tests__/lsp-robustness.test.ts
@@ -25,26 +25,16 @@ vi.mock("@open-rpc/client-js", () => ({
     RequestManager: vi.fn(),
 }));
 
-interface FakeConnection {
-    handlers: Record<string, (message: { data: unknown }) => void>;
-    addEventListener: ReturnType<typeof vi.fn>;
-    removeEventListener: ReturnType<typeof vi.fn>;
-    send: ReturnType<typeof vi.fn>;
-}
-
-function createFakeWebSocketTransport() {
-    const connection: FakeConnection = {
-        handlers: {},
-        addEventListener: vi.fn((event: string, handler) => {
-            connection.handlers[event] = handler;
-        }),
-        removeEventListener: vi.fn((event: string) => {
-            delete connection.handlers[event];
-        }),
-        send: vi.fn(),
-    };
+function createFakeTransport() {
+    // Stands in for the TransportRequestManager every @open-rpc/client-js
+    // transport routes incoming frames through; the client patches
+    // resolveResponse to intercept server->client requests.
+    const originalResolveResponse = vi.fn();
     return {
-        connection,
+        transportRequestManager: {
+            resolveResponse: originalResolveResponse,
+        },
+        originalResolveResponse,
         sendData: vi.fn().mockResolvedValue({}),
         subscribe: vi.fn(),
         unsubscribe: vi.fn(),
@@ -54,7 +44,23 @@ function createFakeWebSocketTransport() {
     } as any;
 }
 
-function baseOptions(transport = createFakeWebSocketTransport()) {
+/** Simulates an incoming frame arriving on the transport */
+// biome-ignore lint/suspicious/noExplicitAny: test helper
+function receiveFrame(transport: any, frame: unknown) {
+    transport.transportRequestManager.resolveResponse(
+        typeof frame === "string" ? frame : JSON.stringify(frame),
+    );
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: inspecting mock args
+function sentResponses(transport: any) {
+    return transport.sendData.mock.calls.map(
+        // biome-ignore lint/suspicious/noExplicitAny: inspecting mock args
+        (call: any[]) => call[0].request,
+    );
+}
+
+function baseOptions(transport = createFakeTransport()) {
     return {
         rootUri: "file:///test",
         workspaceFolders: null,
@@ -102,82 +108,243 @@ describe("initialize failure handling", () => {
     });
 });
 
-describe("WebSocket message handling", () => {
-    it("responds to server requests with id 0", async () => {
-        const transport = createFakeWebSocketTransport();
+describe("server request handling", () => {
+    it("answers unhandled requests with MethodNotFound and a matching id (including id 0)", async () => {
+        const transport = createFakeTransport();
         new LanguageServerClient(baseOptions(transport));
-        const handler = transport.connection.handlers.message;
-        expect(handler).toBeDefined();
 
-        handler({
-            data: JSON.stringify({
+        receiveFrame(transport, {
+            jsonrpc: "2.0",
+            id: 0,
+            method: "window/showMessageRequest",
+            params: {},
+        });
+        await flushTicks();
+
+        expect(sentResponses(transport)).toEqual([
+            {
                 jsonrpc: "2.0",
                 id: 0,
-                method: "client/registerCapability",
-                params: {},
-            }),
-        });
-
-        expect(transport.connection.send).toHaveBeenCalledWith(
-            JSON.stringify({ jsonrpc: "2.0", id: 0, result: null }),
-        );
+                error: {
+                    code: -32601,
+                    message: "Method not found: window/showMessageRequest",
+                },
+            },
+        ]);
+        // The request must not leak into the response/notification path
+        expect(transport.originalResolveResponse).not.toHaveBeenCalled();
     });
 
-    it("ignores non-JSON frames without throwing", () => {
-        const transport = createFakeWebSocketTransport();
-        new LanguageServerClient(baseOptions(transport));
-        const handler = transport.connection.handlers.message;
-
-        expect(() => handler({ data: "ping" })).not.toThrow();
-        expect(() => handler({ data: new Blob(["binary"]) })).not.toThrow();
-        expect(transport.connection.send).not.toHaveBeenCalled();
-    });
-
-    it("answers workspace/configuration requests (including id 0)", () => {
-        const transport = createFakeWebSocketTransport();
+    it("answers workspace/configuration requests via getWorkspaceConfiguration", async () => {
+        const transport = createFakeTransport();
         const getWorkspaceConfiguration = vi.fn().mockReturnValue([{ a: 1 }]);
         new LanguageServerClient({
             ...baseOptions(transport),
             getWorkspaceConfiguration,
         });
-        const handler = transport.connection.handlers.message;
 
-        handler({
-            data: JSON.stringify({
-                jsonrpc: "2.0",
-                id: 0,
-                method: "workspace/configuration",
-                params: { items: [] },
-            }),
+        receiveFrame(transport, {
+            jsonrpc: "2.0",
+            id: 0,
+            method: "workspace/configuration",
+            params: { items: [] },
         });
+        await flushTicks();
 
         expect(getWorkspaceConfiguration).toHaveBeenCalledWith({ items: [] });
-        expect(transport.connection.send).toHaveBeenCalledWith(
-            JSON.stringify({ jsonrpc: "2.0", id: 0, result: [{ a: 1 }] }),
-        );
+        expect(sentResponses(transport)).toEqual([
+            { jsonrpc: "2.0", id: 0, result: [{ a: 1 }] },
+        ]);
     });
 
-    it("does not reply to notifications (no id)", () => {
-        const transport = createFakeWebSocketTransport();
+    it("answers workspace/configuration with one null per item when no option is provided", async () => {
+        const transport = createFakeTransport();
         new LanguageServerClient(baseOptions(transport));
-        const handler = transport.connection.handlers.message;
 
-        handler({
-            data: JSON.stringify({
+        receiveFrame(transport, {
+            jsonrpc: "2.0",
+            id: 7,
+            method: "workspace/configuration",
+            params: { items: [{ section: "a" }, { section: "b" }] },
+        });
+        await flushTicks();
+
+        expect(sentResponses(transport)).toEqual([
+            { jsonrpc: "2.0", id: 7, result: [null, null] },
+        ]);
+    });
+
+    it("dispatches to onRequest handlers and unsubscribes them", async () => {
+        const transport = createFakeTransport();
+        const client = new LanguageServerClient(baseOptions(transport));
+        const handler = vi.fn().mockResolvedValue({ ok: true });
+        const dispose = client.onRequest("custom/method", handler);
+
+        receiveFrame(transport, {
+            jsonrpc: "2.0",
+            id: 1,
+            method: "custom/method",
+            params: { x: 1 },
+        });
+        await flushTicks();
+
+        expect(handler).toHaveBeenCalledWith({ x: 1 });
+        expect(sentResponses(transport)).toEqual([
+            { jsonrpc: "2.0", id: 1, result: { ok: true } },
+        ]);
+
+        dispose();
+        receiveFrame(transport, {
+            jsonrpc: "2.0",
+            id: 2,
+            method: "custom/method",
+            params: {},
+        });
+        await flushTicks();
+
+        expect(handler).toHaveBeenCalledTimes(1);
+        expect(sentResponses(transport)[1]).toEqual({
+            jsonrpc: "2.0",
+            id: 2,
+            error: {
+                code: -32601,
+                message: "Method not found: custom/method",
+            },
+        });
+    });
+
+    it("replies with an internal error when a handler throws, and stays usable", async () => {
+        const transport = createFakeTransport();
+        const client = new LanguageServerClient(baseOptions(transport));
+        client.onRequest("custom/fails", () => {
+            throw new Error("boom");
+        });
+        client.onRequest("custom/works", () => "fine");
+
+        receiveFrame(transport, {
+            jsonrpc: "2.0",
+            id: 1,
+            method: "custom/fails",
+            params: {},
+        });
+        receiveFrame(transport, {
+            jsonrpc: "2.0",
+            id: 2,
+            method: "custom/works",
+            params: {},
+        });
+        await flushTicks();
+
+        expect(sentResponses(transport)).toEqual([
+            {
                 jsonrpc: "2.0",
-                method: "window/logMessage",
-                params: {},
-            }),
+                id: 1,
+                error: { code: -32603, message: "boom" },
+            },
+            { jsonrpc: "2.0", id: 2, result: "fine" },
+        ]);
+    });
+
+    it("coerces a handler's undefined result to null", async () => {
+        const transport = createFakeTransport();
+        const client = new LanguageServerClient(baseOptions(transport));
+        client.onRequest("custom/void", () => undefined);
+
+        receiveFrame(transport, {
+            jsonrpc: "2.0",
+            id: 3,
+            method: "custom/void",
+            params: {},
+        });
+        await flushTicks();
+
+        expect(sentResponses(transport)).toEqual([
+            { jsonrpc: "2.0", id: 3, result: null },
+        ]);
+    });
+
+    it("forwards non-JSON frames, notifications, and responses untouched", async () => {
+        const transport = createFakeTransport();
+        new LanguageServerClient(baseOptions(transport));
+
+        const notification = JSON.stringify({
+            jsonrpc: "2.0",
+            method: "window/logMessage",
+            params: {},
+        });
+        const response = JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            result: { capabilities: {} },
         });
 
-        expect(transport.connection.send).not.toHaveBeenCalled();
+        receiveFrame(transport, "ping");
+        receiveFrame(transport, notification);
+        receiveFrame(transport, response);
+        await flushTicks();
+
+        expect(transport.sendData).not.toHaveBeenCalled();
+        expect(
+            transport.originalResolveResponse.mock.calls.map((c) => c[0]),
+        ).toEqual(["ping", notification, response]);
+    });
+
+    it("tracks dynamic capability (un)registration via hasCapability", async () => {
+        const transport = createFakeTransport();
+        const client = new LanguageServerClient(baseOptions(transport));
+
+        expect(client.hasCapability("textDocument/formatting")).toBe(false);
+
+        receiveFrame(transport, {
+            jsonrpc: "2.0",
+            id: 1,
+            method: "client/registerCapability",
+            params: {
+                registrations: [
+                    {
+                        id: "reg-1",
+                        method: "textDocument/formatting",
+                        registerOptions: {},
+                    },
+                ],
+            },
+        });
+        await flushTicks();
+
+        expect(client.hasCapability("textDocument/formatting")).toBe(true);
+        expect(sentResponses(transport)).toEqual([
+            { jsonrpc: "2.0", id: 1, result: null },
+        ]);
+
+        receiveFrame(transport, {
+            jsonrpc: "2.0",
+            id: 2,
+            method: "client/unregisterCapability",
+            params: {
+                unregisterations: [
+                    { id: "reg-1", method: "textDocument/formatting" },
+                ],
+            },
+        });
+        await flushTicks();
+
+        expect(client.hasCapability("textDocument/formatting")).toBe(false);
+        expect(sentResponses(transport)[1]).toEqual({
+            jsonrpc: "2.0",
+            id: 2,
+            result: null,
+        });
     });
 });
 
 describe("close()", () => {
-    it("marks the client not ready, clears listeners, and detaches the ws handler", async () => {
-        const transport = createFakeWebSocketTransport();
+    it("marks the client not ready, clears listeners, and detaches the request interceptor", async () => {
+        const transport = createFakeTransport();
         const client = new LanguageServerClient(baseOptions(transport));
+        // The constructor patches resolveResponse to intercept server requests
+        expect(transport.transportRequestManager.resolveResponse).not.toBe(
+            transport.originalResolveResponse,
+        );
         await flushTicks();
         expect(client.ready).toBe(true);
 
@@ -187,10 +354,15 @@ describe("close()", () => {
         client.close();
 
         expect(client.ready).toBe(false);
-        expect(transport.connection.removeEventListener).toHaveBeenCalledWith(
-            "message",
-            expect.any(Function),
-        );
+        // Server requests arriving after close are no longer answered
+        receiveFrame(transport, {
+            jsonrpc: "2.0",
+            id: 9,
+            method: "workspace/configuration",
+            params: { items: [] },
+        });
+        await flushTicks();
+        expect(transport.sendData).not.toHaveBeenCalled();
         // biome-ignore lint/suspicious/noExplicitAny: accessing protected member in test
         (client as any).processNotification({
             jsonrpc: "2.0",

--- a/src/__tests__/lsp-robustness.test.ts
+++ b/src/__tests__/lsp-robustness.test.ts
@@ -116,7 +116,7 @@ describe("server request handling", () => {
         receiveFrame(transport, {
             jsonrpc: "2.0",
             id: 0,
-            method: "window/showMessageRequest",
+            method: "workspace/unknownMethod",
             params: {},
         });
         await flushTicks();
@@ -127,12 +127,50 @@ describe("server request handling", () => {
                 id: 0,
                 error: {
                     code: -32601,
-                    message: "Method not found: window/showMessageRequest",
+                    message: "Method not found: workspace/unknownMethod",
                 },
             },
         ]);
         // The request must not leak into the response/notification path
         expect(transport.originalResolveResponse).not.toHaveBeenCalled();
+    });
+
+    it("answers workspace/applyEdit and window requests with spec-valid no-op results", async () => {
+        const transport = createFakeTransport();
+        new LanguageServerClient(baseOptions(transport));
+
+        receiveFrame(transport, {
+            jsonrpc: "2.0",
+            id: 1,
+            method: "workspace/applyEdit",
+            params: { edit: { changes: {} } },
+        });
+        receiveFrame(transport, {
+            jsonrpc: "2.0",
+            id: 2,
+            method: "window/showMessageRequest",
+            params: { type: 1, message: "pick one", actions: [] },
+        });
+        receiveFrame(transport, {
+            jsonrpc: "2.0",
+            id: 3,
+            method: "window/workDoneProgress/create",
+            params: { token: "t" },
+        });
+        await flushTicks();
+
+        expect(sentResponses(transport)).toEqual([
+            {
+                jsonrpc: "2.0",
+                id: 1,
+                result: {
+                    applied: false,
+                    failureReason: "workspace/applyEdit is not supported",
+                },
+            },
+            { jsonrpc: "2.0", id: 2, result: null },
+            { jsonrpc: "2.0", id: 3, result: null },
+        ]);
     });
 
     it("answers workspace/configuration requests via getWorkspaceConfiguration", async () => {

--- a/src/__tests__/plugin-behavior.test.ts
+++ b/src/__tests__/plugin-behavior.test.ts
@@ -3,7 +3,8 @@ import { EditorState } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type * as LSP from "vscode-languageserver-protocol";
-import type { FeatureOptions, LanguageServerClient } from "../lsp.js";
+import { LanguageServerClient } from "../lsp.js";
+import type { FeatureOptions } from "../lsp.js";
 import { LanguageServerPlugin, getLanguageServerPlugin } from "../plugin.js";
 
 const featureOptions: Required<FeatureOptions> = {
@@ -31,6 +32,8 @@ function createFakeClient(overrides: FakeClientOverrides = {}) {
             hoverProvider: true,
             renameProvider: true,
         },
+        dynamicCapabilities: new Map(),
+        hasCapability: LanguageServerClient.prototype.hasCapability,
         initializePromise: overrides.initializePromise ?? Promise.resolve(),
         onNotification: vi.fn().mockReturnValue(() => {}),
         textDocumentDidOpen: vi.fn().mockResolvedValue(undefined),

--- a/src/__tests__/signatureHelpTooltipDismissal.test.ts
+++ b/src/__tests__/signatureHelpTooltipDismissal.test.ts
@@ -1,7 +1,7 @@
 import { EditorState } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { LanguageServerClient } from "../lsp.js";
+import { LanguageServerClient } from "../lsp.js";
 import type { FeatureOptions } from "../lsp.js";
 import {
     LanguageServerPlugin,
@@ -69,6 +69,8 @@ const createMockClient = (): LanguageServerClient => {
                 triggerCharacters: ["(", ","],
             },
         },
+        dynamicCapabilities: new Map(),
+        hasCapability: LanguageServerClient.prototype.hasCapability,
         clientCapabilities: {},
         initializePromise: Promise.resolve(),
         initialize: vi.fn().mockResolvedValue(undefined),

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,10 @@ export {
     setSignatureHelpTooltip,
     suppressSignatureHelp,
 } from "./plugin.js";
-export { LanguageServerClient } from "./lsp.js";
+export {
+    LanguageServerClient,
+    type ServerRequestHandler,
+} from "./lsp.js";
 export {
     languageId,
     documentUri,

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -381,6 +381,31 @@ export class LanguageServerClient {
                 return null;
             },
         );
+        // Minimal spec-valid answers for requests the client cannot fully
+        // honor yet; hosts can override these via onRequest. Truthfully
+        // reporting "not applied" / "no action selected" beats a
+        // MethodNotFound error, which some servers treat as a hard failure.
+        this.onRequest(
+            "workspace/applyEdit",
+            (): LSP.ApplyWorkspaceEditResult => ({
+                applied: false,
+                failureReason: "workspace/applyEdit is not supported",
+            }),
+        );
+        this.onRequest(
+            "window/showMessageRequest",
+            (params: LSP.ShowMessageRequestParams) => {
+                // No UI for message requests; surface the message in the
+                // console and answer null ("no action selected")
+                if (params?.message) {
+                    console.info(`Language server: ${params.message}`);
+                }
+                return null;
+            },
+        );
+        // Acknowledge progress-token creation; the progress notifications
+        // that follow are ignored
+        this.onRequest("window/workDoneProgress/create", () => null);
 
         this.initializePromise = this.initialize();
         // Keep a failed initialize from becoming an unhandled rejection;

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -1,14 +1,14 @@
 import type { autocompletion } from "@codemirror/autocomplete";
 import type { hoverTooltip } from "@codemirror/view";
-import {
-    Client,
-    RequestManager,
-    type WebSocketTransport,
-} from "@open-rpc/client-js";
+import { Client, RequestManager } from "@open-rpc/client-js";
 import type { Transport } from "@open-rpc/client-js/build/transports/Transport.js";
 import type * as LSP from "vscode-languageserver-protocol";
 
 const TIMEOUT = 10000;
+
+// JSON-RPC error codes (https://www.jsonrpc.org/specification#error_object)
+const METHOD_NOT_FOUND = -32601;
+const INTERNAL_ERROR = -32603;
 
 // Client to server then server to client
 export interface LSPRequestMap {
@@ -65,6 +65,90 @@ export type Notification = {
         params: LSPEventMap[key];
     };
 }[keyof LSPEventMap];
+
+/**
+ * Handler for a request initiated by the server (e.g.
+ * `workspace/configuration`, `window/showMessageRequest`). The resolved value
+ * is sent back to the server as the JSON-RPC result; a thrown error is sent
+ * back as a JSON-RPC error response.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: handlers are registered per-method with heterogeneous shapes
+export type ServerRequestHandler<P = any, R = any> = (
+    params: P,
+) => Promise<R> | R;
+
+/** An incoming server->client JSON-RPC request frame */
+interface ServerRequest {
+    jsonrpc: "2.0";
+    id: number | string;
+    method: string;
+    params?: unknown;
+}
+
+interface JsonRpcResponse {
+    jsonrpc: "2.0";
+    id: number | string;
+    result?: unknown;
+    error?: { code: number; message: string };
+}
+
+function isServerRequest(frame: unknown): frame is ServerRequest {
+    if (frame == null || typeof frame !== "object" || Array.isArray(frame)) {
+        return false;
+    }
+    const candidate = frame as Partial<ServerRequest>;
+    // A JSON-RPC id of 0 is valid, so check for presence, not truthiness;
+    // frames with a method but no id are notifications, not requests
+    return (
+        typeof candidate.method === "string" &&
+        candidate.id !== undefined &&
+        candidate.id !== null
+    );
+}
+
+/**
+ * Every @open-rpc/client-js transport funnels each incoming frame through its
+ * TransportRequestManager, which silently drops server->client requests (and
+ * can even mistake them for responses to in-flight client requests when ids
+ * collide). The manager is the only transport-agnostic seam, so we access it
+ * through this narrowed shape.
+ */
+interface InterceptableTransport {
+    transportRequestManager?: {
+        resolveResponse(payload: string, emitError?: boolean): unknown;
+    };
+}
+
+/**
+ * Maps client->server request methods to the static server capability that
+ * announces support for them, for {@link LanguageServerClient.hasCapability}.
+ */
+const METHOD_TO_STATIC_CAPABILITY: Partial<
+    Record<string, keyof LSP.ServerCapabilities>
+> = {
+    "textDocument/hover": "hoverProvider",
+    "textDocument/completion": "completionProvider",
+    "textDocument/definition": "definitionProvider",
+    "textDocument/declaration": "declarationProvider",
+    "textDocument/typeDefinition": "typeDefinitionProvider",
+    "textDocument/implementation": "implementationProvider",
+    "textDocument/references": "referencesProvider",
+    "textDocument/documentHighlight": "documentHighlightProvider",
+    "textDocument/documentSymbol": "documentSymbolProvider",
+    "textDocument/codeAction": "codeActionProvider",
+    "textDocument/codeLens": "codeLensProvider",
+    "textDocument/documentLink": "documentLinkProvider",
+    "textDocument/formatting": "documentFormattingProvider",
+    "textDocument/rangeFormatting": "documentRangeFormattingProvider",
+    "textDocument/onTypeFormatting": "documentOnTypeFormattingProvider",
+    "textDocument/rename": "renameProvider",
+    "textDocument/prepareRename": "renameProvider",
+    "textDocument/signatureHelp": "signatureHelpProvider",
+    "textDocument/foldingRange": "foldingRangeProvider",
+    "textDocument/selectionRange": "selectionRangeProvider",
+    "workspace/symbol": "workspaceSymbolProvider",
+    "workspace/executeCommand": "executeCommandProvider",
+};
 
 /**
  * Options for configuring the language server client
@@ -229,8 +313,16 @@ export class LanguageServerClient {
      * URI from multiple views is not fully synchronized.
      */
     private documentOpenCounts = new Map<string, number>();
-    private webSocketConnection?: WebSocketTransport["connection"];
-    private webSocketMessageHandler?: (message: { data: unknown }) => void;
+    private serverRequestHandlers = new Map<string, ServerRequestHandler>();
+    /**
+     * Capabilities the server registered dynamically via
+     * `client/registerCapability`, keyed by registration id. Consult
+     * {@link hasCapability} to check method support regardless of whether the
+     * server announced it statically or dynamically.
+     */
+    public dynamicCapabilities = new Map<string, LSP.Registration>();
+    private detachServerRequestInterceptor?: () => void;
+    private serverResponseCount = 0;
     private isClosed = false;
 
     constructor({
@@ -257,56 +349,38 @@ export class LanguageServerClient {
             this.processNotification(data as Notification);
         });
 
-        const webSocketTransport = this.transport as WebSocketTransport;
-        if (webSocketTransport?.connection) {
-            this.webSocketConnection = webSocketTransport.connection;
-            this.webSocketMessageHandler = (message: { data: unknown }) => {
-                if (typeof message.data !== "string") {
-                    return;
+        this.detachServerRequestInterceptor =
+            this.attachServerRequestInterceptor(this.transport);
+
+        this.onRequest(
+            "workspace/configuration",
+            (params: LSP.ConfigurationParams) => {
+                if (getWorkspaceConfiguration) {
+                    return getWorkspaceConfiguration(params);
                 }
-                // biome-ignore lint/suspicious/noExplicitAny: raw JSON-RPC frame
-                let data: any;
-                try {
-                    data = JSON.parse(message.data);
-                } catch {
-                    // Ignore non-JSON frames (e.g. keepalive pings)
-                    return;
+                // Per spec the result must have one entry per requested item
+                return (params?.items ?? []).map(() => null);
+            },
+        );
+        this.onRequest(
+            "client/registerCapability",
+            (params: LSP.RegistrationParams) => {
+                for (const registration of params?.registrations ?? []) {
+                    this.dynamicCapabilities.set(registration.id, registration);
                 }
-                if (data == null || typeof data !== "object") {
-                    return;
+                return null;
+            },
+        );
+        this.onRequest(
+            "client/unregisterCapability",
+            (params: LSP.UnregistrationParams) => {
+                // "unregisterations" is a spelling mistake baked into the LSP spec
+                for (const unregistration of params?.unregisterations ?? []) {
+                    this.dynamicCapabilities.delete(unregistration.id);
                 }
-                // A JSON-RPC id of 0 is valid, so check for presence, not truthiness
-                const isRequest = data.id !== undefined && data.id !== null;
-                if (
-                    data.method === "workspace/configuration" &&
-                    isRequest &&
-                    getWorkspaceConfiguration
-                ) {
-                    webSocketTransport.connection.send(
-                        JSON.stringify({
-                            jsonrpc: "2.0",
-                            id: data.id,
-                            result: getWorkspaceConfiguration(data.params),
-                        }),
-                    );
-                    // XXX(hjr265): Need a better way to do this. Relevant issue:
-                    // https://github.com/FurqanSoftware/codemirror-languageserver/issues/9
-                } else if (data.method && isRequest) {
-                    webSocketTransport.connection.send(
-                        JSON.stringify({
-                            jsonrpc: "2.0",
-                            id: data.id,
-                            result: null,
-                        }),
-                    );
-                }
-            };
-            webSocketTransport.connection.addEventListener(
-                "message",
-                // @ts-ignore
-                this.webSocketMessageHandler,
-            );
-        }
+                return null;
+            },
+        );
 
         this.initializePromise = this.initialize();
         // Keep a failed initialize from becoming an unhandled rejection;
@@ -317,6 +391,11 @@ export class LanguageServerClient {
     }
 
     protected getInitializationOptions(): LSP.InitializeParams["initializationOptions"] {
+        // dynamicRegistration is only advertised for features whose support
+        // checks go through hasCapability() and whose registrations carry no
+        // options the client would otherwise ignore. Everything else stays
+        // false so servers announce those capabilities statically instead of
+        // registering behavior we cannot honor.
         const defaultClientCapabilities: LSP.ClientCapabilities = {
             textDocument: {
                 hover: {
@@ -325,7 +404,7 @@ export class LanguageServerClient {
                 },
                 moniker: {},
                 synchronization: {
-                    dynamicRegistration: true,
+                    dynamicRegistration: false,
                     willSave: true,
                     didSave: true,
                     willSaveWaitUntil: true,
@@ -351,7 +430,10 @@ export class LanguageServerClient {
                     },
                 },
                 completion: {
-                    dynamicRegistration: true,
+                    // Dynamic completion registrations carry triggerCharacters
+                    // and resolveProvider options that are still read from the
+                    // static capability only
+                    dynamicRegistration: false,
                     completionItem: {
                         snippetSupport: true,
                         commitCharactersSupport: true,
@@ -362,13 +444,15 @@ export class LanguageServerClient {
                     contextSupport: false,
                 },
                 signatureHelp: {
-                    dynamicRegistration: true,
+                    // Same as completion: triggerCharacters come from the
+                    // static capability only
+                    dynamicRegistration: false,
                     signatureInformation: {
                         documentationFormat: ["markdown", "plaintext"],
                     },
                 },
                 declaration: {
-                    dynamicRegistration: true,
+                    dynamicRegistration: false,
                     linkSupport: true,
                 },
                 definition: {
@@ -376,11 +460,11 @@ export class LanguageServerClient {
                     linkSupport: true,
                 },
                 typeDefinition: {
-                    dynamicRegistration: true,
+                    dynamicRegistration: false,
                     linkSupport: true,
                 },
                 implementation: {
-                    dynamicRegistration: true,
+                    dynamicRegistration: false,
                     linkSupport: true,
                 },
                 rename: {
@@ -390,7 +474,7 @@ export class LanguageServerClient {
             },
             workspace: {
                 didChangeConfiguration: {
-                    dynamicRegistration: true,
+                    dynamicRegistration: false,
                 },
             },
         };
@@ -430,16 +514,143 @@ export class LanguageServerClient {
         this.isClosed = true;
         this.ready = false;
         this.notificationListeners.clear();
-        if (this.webSocketConnection && this.webSocketMessageHandler) {
-            this.webSocketConnection.removeEventListener(
-                "message",
-                // @ts-ignore
-                this.webSocketMessageHandler,
-            );
-            this.webSocketConnection = undefined;
-            this.webSocketMessageHandler = undefined;
-        }
+        this.serverRequestHandlers.clear();
+        this.dynamicCapabilities.clear();
+        this.detachServerRequestInterceptor?.();
+        this.detachServerRequestInterceptor = undefined;
         this.client.close();
+    }
+
+    /**
+     * Registers a handler for a request initiated by the server. The handler's
+     * resolved value is sent back as the JSON-RPC result; a thrown error
+     * becomes a JSON-RPC error response. Requests with no registered handler
+     * are answered with a `MethodNotFound` (-32601) error so servers can fall
+     * back gracefully.
+     *
+     * @returns A function that removes the handler.
+     */
+    public onRequest(
+        method: string,
+        handler: ServerRequestHandler,
+    ): () => void {
+        this.serverRequestHandlers.set(method, handler);
+        return () => {
+            // Don't remove a newer handler registered for the same method
+            if (this.serverRequestHandlers.get(method) === handler) {
+                this.serverRequestHandlers.delete(method);
+            }
+        };
+    }
+
+    /**
+     * Whether the server supports the given client->server method, counting
+     * both statically announced capabilities and capabilities the server
+     * registered dynamically via `client/registerCapability`.
+     */
+    public hasCapability(method: string): boolean {
+        for (const registration of this.dynamicCapabilities.values()) {
+            if (registration.method === method) {
+                return true;
+            }
+        }
+        const capability = METHOD_TO_STATIC_CAPABILITY[method];
+        if (!capability) {
+            return false;
+        }
+        return Boolean(this.capabilities?.[capability]);
+    }
+
+    /**
+     * Patches the transport's TransportRequestManager so server->client
+     * requests are dispatched to {@link serverRequestHandlers} instead of
+     * being silently dropped (or, worse, matched against a pending client
+     * request with a colliding id). Responses and notifications still flow
+     * through the original code path untouched.
+     */
+    private attachServerRequestInterceptor(
+        transport: Transport,
+    ): (() => void) | undefined {
+        const manager = (transport as unknown as InterceptableTransport)
+            .transportRequestManager;
+        if (!manager || typeof manager.resolveResponse !== "function") {
+            return undefined;
+        }
+        const original = manager.resolveResponse.bind(manager);
+        manager.resolveResponse = (payload: string, emitError?: boolean) => {
+            if (typeof payload === "string") {
+                let frame: unknown;
+                try {
+                    frame = JSON.parse(payload);
+                } catch {
+                    frame = undefined;
+                }
+                if (isServerRequest(frame)) {
+                    void this.handleServerRequest(frame);
+                    return undefined;
+                }
+            }
+            return original(payload, emitError);
+        };
+        return () => {
+            manager.resolveResponse = original;
+        };
+    }
+
+    private async handleServerRequest(request: ServerRequest): Promise<void> {
+        const handler = this.serverRequestHandlers.get(request.method);
+        let response: JsonRpcResponse;
+        if (!handler) {
+            response = {
+                jsonrpc: "2.0",
+                id: request.id,
+                error: {
+                    code: METHOD_NOT_FOUND,
+                    message: `Method not found: ${request.method}`,
+                },
+            };
+        } else {
+            try {
+                const result = await handler(request.params);
+                response = {
+                    jsonrpc: "2.0",
+                    id: request.id,
+                    // JSON.stringify drops `result: undefined`, which would
+                    // produce a spec-invalid response; send an explicit null
+                    result: result === undefined ? null : result,
+                };
+            } catch (error) {
+                response = {
+                    jsonrpc: "2.0",
+                    id: request.id,
+                    error: {
+                        code: INTERNAL_ERROR,
+                        message:
+                            error instanceof Error
+                                ? error.message
+                                : String(error),
+                    },
+                };
+            }
+        }
+        if (this.isClosed) {
+            return;
+        }
+        // sendData wraps outgoing payloads in {internalID, request} and sends
+        // `request` verbatim, so a raw response object rides through any
+        // transport. Because the response carries an id, the transport tracks
+        // it as if it were a request awaiting an answer that never comes; the
+        // timeout cleans up that entry and the rejection is expected.
+        const internalID = `codemirror-languageserver:server-reply:${this.serverResponseCount++}`;
+        try {
+            await this.transport.sendData(
+                // biome-ignore lint/suspicious/noExplicitAny: a response frame is not part of JSONRPCRequestData
+                { internalID, request: response as any },
+                this.timeout,
+            );
+        } catch {
+            // Expected: responses get no acknowledgement
+        }
     }
 
     public textDocumentDidOpen(params: LSP.DidOpenTextDocumentParams) {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -459,7 +459,12 @@ export class LanguageServerPlugin implements PluginValue {
             return null;
         }
 
-        if (!(this.client.ready && this.client.capabilities?.hoverProvider)) {
+        if (
+            !(
+                this.client.ready &&
+                this.client.hasCapability("textDocument/hover")
+            )
+        ) {
             return null;
         }
 
@@ -517,7 +522,10 @@ export class LanguageServerPlugin implements PluginValue {
         await Promise.all(this.pendingDocumentChanges);
 
         if (
-            !(this.client.ready && this.client.capabilities?.completionProvider)
+            !(
+                this.client.ready &&
+                this.client.hasCapability("textDocument/completion")
+            )
         ) {
             return null;
         }
@@ -590,7 +598,10 @@ export class LanguageServerPlugin implements PluginValue {
         }
 
         if (
-            !(this.client.ready && this.client.capabilities?.definitionProvider)
+            !(
+                this.client.ready &&
+                this.client.hasCapability("textDocument/definition")
+            )
         ) {
             return;
         }
@@ -823,7 +834,10 @@ export class LanguageServerPlugin implements PluginValue {
         }
 
         if (
-            !(this.client.ready && this.client.capabilities?.codeActionProvider)
+            !(
+                this.client.ready &&
+                this.client.hasCapability("textDocument/codeAction")
+            )
         ) {
             return null;
         }
@@ -858,7 +872,7 @@ export class LanguageServerPlugin implements PluginValue {
             return;
         }
 
-        if (!this.client.capabilities?.renameProvider) {
+        if (!this.client.hasCapability("textDocument/rename")) {
             showErrorMessage(view, "Rename not supported by language server");
             return;
         }
@@ -1024,7 +1038,7 @@ export class LanguageServerPlugin implements PluginValue {
             !(
                 this.featureOptions.signatureHelpEnabled &&
                 this.client.ready &&
-                this.client.capabilities?.signatureHelpProvider
+                this.client.hasCapability("textDocument/signatureHelp")
             )
         ) {
             return null;
@@ -1645,13 +1659,14 @@ export function languageServerWithClient(options: LanguageServerOptions) {
                     return;
 
                 // Early exit if signature help capability is not supported
-                if (!plugin.client.capabilities?.signatureHelpProvider) return;
+                if (!plugin.client.hasCapability("textDocument/signatureHelp"))
+                    return;
 
                 // Only proceed if signatureActivateOnTyping is enabled
                 if (!featuresOptions.signatureActivateOnTyping) return;
 
                 const triggerChars = plugin.client.capabilities
-                    .signatureHelpProvider.triggerCharacters || ["(", ","];
+                    ?.signatureHelpProvider?.triggerCharacters || ["(", ","];
 
                 // Check if changes include trigger characters
                 const changes = update.changes;


### PR DESCRIPTION
## Problem

`LanguageServerClient` handled server->client requests with a raw `message` listener on the WebSocket connection that answered `workspace/configuration` and replied `{ result: null }` to **every other request**. Consequences:

- `client/registerCapability` / `client/unregisterCapability` were answered `null` and dropped — while the default client capabilities advertised `dynamicRegistration: true` almost everywhere, actively inviting servers to use a mechanism we ignored (servers like pyright would then never announce completion statically, silently degrading features).
- `null` is a spec-invalid answer for several requests (`window/showMessageRequest`, `window/workDoneProgress/create`, ...).
- The hack only worked for `WebSocketTransport`; any other `Transport` (postMessage, worker) got no server-request handling at all.
- Latent bug: a server request whose `id` collided with an in-flight client request id could be consumed by `@open-rpc/client-js` as that request's *response*, resolving it with `undefined`.

## Changes

**Transport-agnostic dispatcher.** Server requests are intercepted by patching the transport's `TransportRequestManager.resolveResponse` — the one seam every `@open-rpc/client-js` transport funnels incoming frames through (the library itself silently drops server requests, so frames never pass through an outer wrapper transport). Responses/notifications flow through untouched; replies ride `transport.sendData`, so this works on all transports.

**`onRequest(method, handler)`** (returns an unsubscribe fn):
- handler result -> JSON-RPC result (`undefined` coerced to `null`)
- handler throw -> `-32603` error response, connection stays usable
- no handler -> spec-correct `MethodNotFound` (`-32601`) instead of `result: null`, letting servers fall back gracefully

**Built-in handlers** registered in the constructor:
- `workspace/configuration` -> existing `getWorkspaceConfiguration` option; without it, one `null` per requested item (spec requires the array shape)
- `client/registerCapability` / `client/unregisterCapability` -> tracked in a public `dynamicCapabilities` map
- `workspace/applyEdit` and `window/*` handlers (plans 02/18) can now be plain `onRequest` calls

**`hasCapability(method)`** treats a dynamic registration as equivalent to the static capability; all plugin provider gates (hover, completion, definition, codeAction, rename, signatureHelp) now go through it. Option detail reads (`triggerCharacters`, `resolveProvider`) still use the static capability object.

**Capability honesty pass.** `dynamicRegistration` stays `true` only for hover, definition, codeAction, and rename — features whose gating is handled via `hasCapability` and whose registrations carry no options we would ignore. Completion, signatureHelp, synchronization, declaration, typeDefinition, implementation, and didChangeConfiguration are now `false`, so servers announce those capabilities statically instead of registering behavior we cannot honor.

## Notes for consumers

- Hand-built client stubs passed to `languageServerWithClient` (e.g. `{...} as unknown as LanguageServerClient` in tests) need a `hasCapability` implementation now — real instances/subclasses are unaffected.
- Users passing `capabilities` as an object are untouched by the honesty pass; function form receives the new defaults as input.
- Servers now see `-32601` for unsupported requests instead of a `null` result (WebSocket) or silence (other transports).

## Testing

- unhandled request -> `-32601` with matching id (including id 0); frame does not leak into the response/notification path
- `workspace/configuration` unchanged with the option; per-item `null` fallback without it
- `client/registerCapability` for `textDocument/formatting` -> `hasCapability` true; unregister -> false
- handler throw -> `-32603`, subsequent requests still answered
- non-JSON frames / notifications / responses forwarded untouched; interceptor detached on `close()`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make server->client requests work on all transports and honor dynamic capability registration. Add default, spec-valid replies for `workspace/applyEdit` and `window/*` to avoid hard failures.

- **New Features**
  - Transport-agnostic dispatcher by patching `TransportRequestManager.resolveResponse` in `@open-rpc/client-js`; replies are sent via `transport.sendData`.
  - `onRequest(method, handler)`: result -> JSON-RPC result (undefined -> null); throw -> -32603; unhandled -> -32601.
  - Built-in handlers: `workspace/configuration`; `client/(un)registerCapability` tracked in `dynamicCapabilities`; spec-valid no-ops for `workspace/applyEdit` and `window/{showMessageRequest,workDoneProgress/create}`.
  - `hasCapability(method)` counts static + dynamic support; plugin gates for hover/completion/definition/codeAction/rename/signatureHelp now use it.
  - Capability honesty: `dynamicRegistration: true` only for hover, definition, codeAction, rename; others set to false.
  - Exported `ServerRequestHandler`.

- **Migration**
  - If you pass a hand-built client stub to `languageServerWithClient`, implement `hasCapability(method)`; real instances are unaffected.
  - Capability function inputs now reflect the new defaults; object form is unchanged.
  - Unsupported requests now receive `-32601` instead of `result: null`; `workspace/applyEdit` and `window/*` get spec-valid no-op results.

<sup>Written for commit 173fa0716ca2f942fa1fa8d69c9a1e8288895582. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marimo-team/codemirror-languageserver/pull/78?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

