### PR TITLE
feat: close completion spec gaps (itemDefaults, InsertReplaceEdit, commitCharacters, deprecated items, lazy additionalTextEdits)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,28 @@ const view = new EditorView({
 
 ## Advanced Configuration
 
+### Completion Behavior
+
+```typescript
+const ls = languageServer({
+  // ...
+
+  // Optional: Filter complete (`isIncomplete: false`) completion lists
+  // client-side instead of re-querying the server on every keystroke.
+  clientSideFiltering: true,
+});
+```
+
+Completion items the server marks deprecated get a `cm-deprecated` class,
+shown with a strikethrough by default. Override with:
+
+```css
+.cm-tooltip-autocomplete li.cm-deprecated .cm-completionLabel {
+  text-decoration: line-through;
+  opacity: 0.7;
+}
+```
+
 ### Sharing Client Across Multiple Instances
 
 ```typescript

--- a/src/__tests__/completion-apply.test.ts
+++ b/src/__tests__/completion-apply.test.ts
@@ -474,3 +474,44 @@ describe("convertCompletionItem lazy additionalTextEdits", () => {
         expect(view.state.doc.toString()).toBe("foobar x");
     });
 });
+
+describe("convertCompletionItem lazy edits racing user input", () => {
+    it("drops resolve-provided edits when the document changed during resolve", async () => {
+        const view = createView("f x");
+        const item: LSP.CompletionItem = {
+            label: "foobar",
+            insertText: "foobar",
+        };
+        let resolveNow: (value: LSP.CompletionItem) => void = () => {};
+        const resolveItem = vi.fn().mockReturnValue(
+            new Promise<LSP.CompletionItem>((resolve) => {
+                resolveNow = resolve;
+            }),
+        );
+        const completion = convertCompletionItem(item, {
+            ...defaultOptions,
+            hasResolveProvider: true,
+            resolveItem,
+        });
+        // biome-ignore lint/suspicious/noExplicitAny: test invokes apply directly
+        (completion.apply as any)(view, completion, 0, 1);
+        expect(view.state.doc.toString()).toBe("foobar x");
+
+        // User keeps typing before the resolve response arrives
+        view.dispatch({ changes: { from: 6, to: 6, insert: "!" } });
+        resolveNow({
+            ...item,
+            additionalTextEdits: [
+                {
+                    range: {
+                        start: { line: 0, character: 2 },
+                        end: { line: 0, character: 3 },
+                    },
+                    newText: "imported",
+                },
+            ],
+        });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(view.state.doc.toString()).toBe("foobar! x");
+    });
+});

--- a/src/__tests__/completion-apply.test.ts
+++ b/src/__tests__/completion-apply.test.ts
@@ -299,3 +299,178 @@ describe("sortCompletionItems with opaque sortText", () => {
         expect(sorted.map((i) => i.label)).toEqual(["temp", "test"]);
     });
 });
+
+describe("convertCompletionItem InsertReplaceEdit", () => {
+    it("applies an InsertReplaceEdit using its replace range", () => {
+        // Cursor after "fo" inside the token "foXX"; replace covers the
+        // whole token while insert only covers the typed prefix
+        const view = createView("foXX");
+        const item: LSP.CompletionItem = {
+            label: "foobar",
+            textEdit: {
+                newText: "foobar",
+                insert: {
+                    start: { line: 0, character: 0 },
+                    end: { line: 0, character: 2 },
+                },
+                replace: {
+                    start: { line: 0, character: 0 },
+                    end: { line: 0, character: 4 },
+                },
+            },
+        };
+        const completion = convertCompletionItem(item, defaultOptions);
+        // biome-ignore lint/suspicious/noExplicitAny: test invokes apply directly
+        (completion.apply as any)(view, completion, 0, 2);
+        expect(view.state.doc.toString()).toBe("foobar");
+    });
+
+    it("falls back to the token range when the replace range is invalid", () => {
+        const view = createView("fo");
+        const item: LSP.CompletionItem = {
+            label: "foobar",
+            textEdit: {
+                newText: "foobar",
+                insert: {
+                    start: { line: 0, character: 0 },
+                    end: { line: 0, character: 2 },
+                },
+                replace: {
+                    start: { line: 0, character: 0 },
+                    end: { line: 9, character: 9 },
+                },
+            },
+        };
+        const completion = convertCompletionItem(item, defaultOptions);
+        // biome-ignore lint/suspicious/noExplicitAny: test invokes apply directly
+        (completion.apply as any)(view, completion, 0, 2);
+        expect(view.state.doc.toString()).toBe("foobar");
+    });
+});
+
+describe("convertCompletionItem lazy additionalTextEdits", () => {
+    it("applies additionalTextEdits arriving via completionItem/resolve", async () => {
+        // "f x" -> main edit replaces "f" (0-1) with "foobar"; the resolve
+        // response brings an edit replacing "x" (2-3, pre-completion coords)
+        const view = createView("f x");
+        const item: LSP.CompletionItem = {
+            label: "foobar",
+            insertText: "foobar",
+        };
+        const resolveItem = vi.fn().mockResolvedValue({
+            ...item,
+            additionalTextEdits: [
+                {
+                    range: {
+                        start: { line: 0, character: 2 },
+                        end: { line: 0, character: 3 },
+                    },
+                    newText: "imported",
+                },
+            ],
+        });
+        const completion = convertCompletionItem(item, {
+            ...defaultOptions,
+            hasResolveProvider: true,
+            resolveItem,
+        });
+        // biome-ignore lint/suspicious/noExplicitAny: test invokes apply directly
+        (completion.apply as any)(view, completion, 0, 1);
+        expect(view.state.doc.toString()).toBe("foobar x");
+        await vi.waitFor(() =>
+            expect(view.state.doc.toString()).toBe("foobar imported"),
+        );
+    });
+
+    it("applies resolve-provided edits after a snippet expansion", async () => {
+        const view = createView("f x");
+        const item: LSP.CompletionItem = {
+            label: "foo",
+            insertText: "foo($1)",
+            insertTextFormat: 2, // Snippet
+        };
+        const resolveItem = vi.fn().mockResolvedValue({
+            ...item,
+            additionalTextEdits: [
+                {
+                    range: {
+                        start: { line: 0, character: 2 },
+                        end: { line: 0, character: 3 },
+                    },
+                    newText: "import",
+                },
+            ],
+        });
+        const completion = convertCompletionItem(item, {
+            ...defaultOptions,
+            useSnippetOnCompletion: true,
+            hasResolveProvider: true,
+            resolveItem,
+        });
+        // biome-ignore lint/suspicious/noExplicitAny: test invokes apply directly
+        (completion.apply as any)(view, completion, 0, 1);
+        await vi.waitFor(() =>
+            expect(view.state.doc.toString()).toBe("foo() import"),
+        );
+    });
+
+    it("does not re-apply edits the item already carried", async () => {
+        const view = createView("f x");
+        const item: LSP.CompletionItem = {
+            label: "foobar",
+            insertText: "foobar",
+            additionalTextEdits: [
+                {
+                    range: {
+                        start: { line: 0, character: 2 },
+                        end: { line: 0, character: 3 },
+                    },
+                    newText: "imported",
+                },
+            ],
+        };
+        const resolveItem = vi.fn().mockResolvedValue(item);
+        const completion = convertCompletionItem(item, {
+            ...defaultOptions,
+            hasResolveProvider: true,
+            resolveItem,
+        });
+        // biome-ignore lint/suspicious/noExplicitAny: test invokes apply directly
+        (completion.apply as any)(view, completion, 0, 1);
+        expect(view.state.doc.toString()).toBe("foobar imported");
+        // Give any stray resolve a chance to run, then check nothing changed
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(resolveItem).not.toHaveBeenCalled();
+        expect(view.state.doc.toString()).toBe("foobar imported");
+    });
+
+    it("skips resolve-provided edits that overlap the main edit", async () => {
+        const view = createView("f x");
+        const item: LSP.CompletionItem = {
+            label: "foobar",
+            insertText: "foobar",
+        };
+        const resolveItem = vi.fn().mockResolvedValue({
+            ...item,
+            additionalTextEdits: [
+                {
+                    // Overlaps the main edit [0, 1)
+                    range: {
+                        start: { line: 0, character: 0 },
+                        end: { line: 0, character: 1 },
+                    },
+                    newText: "clobber",
+                },
+            ],
+        });
+        const completion = convertCompletionItem(item, {
+            ...defaultOptions,
+            hasResolveProvider: true,
+            resolveItem,
+        });
+        // biome-ignore lint/suspicious/noExplicitAny: test invokes apply directly
+        (completion.apply as any)(view, completion, 0, 1);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(view.state.doc.toString()).toBe("foobar x");
+    });
+});

--- a/src/__tests__/completion.test.ts
+++ b/src/__tests__/completion.test.ts
@@ -1,7 +1,17 @@
+import { Text } from "@codemirror/state";
 import { describe, expect, it, vi } from "vitest";
 import type * as LSP from "vscode-languageserver-protocol";
 import { CompletionItemKind } from "vscode-languageserver-protocol";
-import { convertCompletionItem, convertSnippet } from "../completion.js";
+import {
+    completionOptionClass,
+    convertAdditionalTextEdits,
+    convertCompletionItem,
+    convertSnippet,
+    isDeprecatedItem,
+    mapThroughReplacement,
+    resolveItemDefaults,
+    resolveMainEdit,
+} from "../completion.js";
 import { sortCompletionItems } from "../completion.js";
 
 describe("convertCompletionItem", () => {
@@ -528,5 +538,294 @@ describe("convertSnippet", () => {
         const input = String.raw`\${1:price}`;
         const result = convertSnippet(input);
         expect(result).toBe(String.raw`$\{1:price}`);
+    });
+});
+
+describe("resolveItemDefaults", () => {
+    const range: LSP.Range = {
+        start: { line: 0, character: 0 },
+        end: { line: 0, character: 3 },
+    };
+
+    it("returns the item unchanged when there are no defaults", () => {
+        const item: LSP.CompletionItem = { label: "test" };
+        expect(resolveItemDefaults(item, undefined)).toBe(item);
+    });
+
+    it("fills commitCharacters, insertTextFormat, insertTextMode and data from defaults", () => {
+        const resolved = resolveItemDefaults(
+            { label: "test" },
+            {
+                commitCharacters: ["."],
+                insertTextFormat: 2,
+                insertTextMode: 1,
+                data: { id: 1 },
+            },
+        );
+        expect(resolved).toEqual({
+            label: "test",
+            commitCharacters: ["."],
+            insertTextFormat: 2,
+            insertTextMode: 1,
+            data: { id: 1 },
+        });
+    });
+
+    it("prefers fields set on the item over defaults", () => {
+        const resolved = resolveItemDefaults(
+            {
+                label: "test",
+                commitCharacters: ["("],
+                insertTextFormat: 1,
+                data: { id: 2 },
+                textEdit: { range, newText: "own" },
+            },
+            {
+                commitCharacters: ["."],
+                insertTextFormat: 2,
+                data: { id: 1 },
+                editRange: range,
+            },
+        );
+        expect(resolved.commitCharacters).toEqual(["("]);
+        expect(resolved.insertTextFormat).toBe(1);
+        expect(resolved.data).toEqual({ id: 2 });
+        expect(resolved.textEdit).toEqual({ range, newText: "own" });
+    });
+
+    it("converts a plain default editRange into a textEdit", () => {
+        const resolved = resolveItemDefaults(
+            { label: "test" },
+            { editRange: range },
+        );
+        expect(resolved.textEdit).toEqual({ range, newText: "test" });
+    });
+
+    it("uses textEditText over label for a default editRange", () => {
+        const resolved = resolveItemDefaults(
+            { label: "test", textEditText: "test()" },
+            { editRange: range },
+        );
+        expect(resolved.textEdit).toEqual({ range, newText: "test()" });
+    });
+
+    it("converts an insert/replace default editRange into an InsertReplaceEdit", () => {
+        const insert: LSP.Range = {
+            start: { line: 0, character: 0 },
+            end: { line: 0, character: 2 },
+        };
+        const resolved = resolveItemDefaults(
+            { label: "test" },
+            { editRange: { insert, replace: range } },
+        );
+        expect(resolved.textEdit).toEqual({
+            insert,
+            replace: range,
+            newText: "test",
+        });
+    });
+});
+
+describe("completion item metadata", () => {
+    const defaultOptions = {
+        allowHTMLContent: false,
+        useSnippetOnCompletion: false,
+        hasResolveProvider: false,
+        resolveItem: vi.fn(),
+    };
+
+    it("passes commitCharacters through to the CodeMirror completion", () => {
+        const completion = convertCompletionItem(
+            { label: "test", commitCharacters: [".", "("] },
+            defaultOptions,
+        );
+        expect(completion.commitCharacters).toEqual([".", "("]);
+    });
+
+    it("marks items deprecated via tags", () => {
+        const completion = convertCompletionItem(
+            { label: "test", tags: [1] },
+            defaultOptions,
+        );
+        expect(completion.deprecated).toBe(true);
+    });
+
+    it("marks items deprecated via the legacy deprecated flag", () => {
+        const completion = convertCompletionItem(
+            { label: "test", deprecated: true },
+            defaultOptions,
+        );
+        expect(completion.deprecated).toBe(true);
+    });
+
+    it("leaves non-deprecated items unmarked", () => {
+        const completion = convertCompletionItem(
+            { label: "test" },
+            defaultOptions,
+        );
+        expect(completion.deprecated).toBeUndefined();
+    });
+});
+
+describe("sortCompletionItems client-side filtering mode", () => {
+    it("keeps non-matching items when filtering is disabled", () => {
+        const items: LSP.CompletionItem[] = [
+            { label: "foo" },
+            { label: "bar" },
+        ];
+        const sorted = sortCompletionItems(items, "fo", "javascript", false);
+        expect(sorted.map((i) => i.label)).toEqual(["foo", "bar"]);
+    });
+
+    it("still filters by default", () => {
+        const items: LSP.CompletionItem[] = [
+            { label: "foo" },
+            { label: "bar" },
+        ];
+        const sorted = sortCompletionItems(items, "fo", "javascript");
+        expect(sorted.map((i) => i.label)).toEqual(["foo"]);
+    });
+});
+
+describe("resolveMainEdit", () => {
+    const doc = Text.of(["hello world"]);
+
+    it("falls back to the token range and insertText without a textEdit", () => {
+        expect(
+            resolveMainEdit(
+                doc,
+                { label: "hello", insertText: "hello()" },
+                0,
+                3,
+            ),
+        ).toEqual({ from: 0, to: 3, newText: "hello()" });
+    });
+
+    it("uses a TextEdit's range and text", () => {
+        expect(
+            resolveMainEdit(
+                doc,
+                {
+                    label: "hello",
+                    textEdit: {
+                        range: {
+                            start: { line: 0, character: 0 },
+                            end: { line: 0, character: 5 },
+                        },
+                        newText: "goodbye",
+                    },
+                },
+                0,
+                3,
+            ),
+        ).toEqual({ from: 0, to: 5, newText: "goodbye" });
+    });
+
+    it("uses the replace range of an InsertReplaceEdit", () => {
+        expect(
+            resolveMainEdit(
+                doc,
+                {
+                    label: "hello",
+                    textEdit: {
+                        newText: "goodbye",
+                        insert: {
+                            start: { line: 0, character: 0 },
+                            end: { line: 0, character: 3 },
+                        },
+                        replace: {
+                            start: { line: 0, character: 0 },
+                            end: { line: 0, character: 5 },
+                        },
+                    },
+                },
+                0,
+                3,
+            ),
+        ).toEqual({ from: 0, to: 5, newText: "goodbye" });
+    });
+
+    it("keeps the edit text but falls back to the token range when the edit range is stale", () => {
+        expect(
+            resolveMainEdit(
+                doc,
+                {
+                    label: "hello",
+                    textEdit: {
+                        range: {
+                            start: { line: 0, character: 0 },
+                            end: { line: 9, character: 9 },
+                        },
+                        newText: "goodbye",
+                    },
+                },
+                0,
+                3,
+            ),
+        ).toEqual({ from: 0, to: 3, newText: "goodbye" });
+    });
+});
+
+describe("convertAdditionalTextEdits", () => {
+    const doc = Text.of(["hello world"]);
+    const edit = (
+        startChar: number,
+        endChar: number,
+        newText: string,
+        line = 0,
+    ): LSP.TextEdit => ({
+        range: {
+            start: { line, character: startChar },
+            end: { line, character: endChar },
+        },
+        newText,
+    });
+
+    it("converts edits to offset changes", () => {
+        expect(
+            convertAdditionalTextEdits(doc, [edit(6, 11, "there")], 0, 5),
+        ).toEqual([{ from: 6, to: 11, insert: "there" }]);
+    });
+
+    it("drops edits overlapping the main edit", () => {
+        expect(
+            convertAdditionalTextEdits(doc, [edit(4, 7, "x")], 0, 5),
+        ).toEqual([]);
+    });
+
+    it("drops edits with stale ranges", () => {
+        expect(
+            convertAdditionalTextEdits(doc, [edit(0, 4, "x", 9)], 6, 11),
+        ).toEqual([]);
+    });
+});
+
+describe("mapThroughReplacement", () => {
+    // Replacement of [2, 5) by 7 characters
+    const mapPos = mapThroughReplacement(2, 5, 7);
+
+    it("keeps positions before the replacement", () => {
+        expect(mapPos(0)).toBe(0);
+        expect(mapPos(2)).toBe(2);
+    });
+
+    it("shifts positions after the replacement by the length delta", () => {
+        expect(mapPos(5)).toBe(9);
+        expect(mapPos(10)).toBe(14);
+    });
+});
+
+describe("isDeprecatedItem / completionOptionClass", () => {
+    it("detects deprecation via tags and legacy flag", () => {
+        expect(isDeprecatedItem({ tags: [1] })).toBe(true);
+        expect(isDeprecatedItem({ deprecated: true })).toBe(true);
+        expect(isDeprecatedItem({})).toBe(false);
+    });
+
+    it("returns cm-deprecated only for deprecated completions", () => {
+        expect(completionOptionClass({ label: "a", deprecated: true })).toBe(
+            "cm-deprecated",
+        );
+        expect(completionOptionClass({ label: "a" })).toBe("");
     });
 });

--- a/src/__tests__/completion.test.ts
+++ b/src/__tests__/completion.test.ts
@@ -829,3 +829,34 @@ describe("isDeprecatedItem / completionOptionClass", () => {
         expect(completionOptionClass({ label: "a" })).toBe("");
     });
 });
+
+describe("filterText mapping", () => {
+    const defaultOptions = {
+        allowHTMLContent: false,
+        useSnippetOnCompletion: false,
+        hasResolveProvider: false,
+        resolveItem: vi.fn(),
+    };
+
+    it("matches against filterText and displays the LSP label", () => {
+        const completion = convertCompletionItem(
+            { label: "• foo", filterText: "foo" },
+            defaultOptions,
+        );
+        expect(completion.label).toBe("foo");
+        expect(completion.displayLabel).toBe("• foo");
+    });
+
+    it("leaves the label alone when filterText is absent or identical", () => {
+        expect(
+            convertCompletionItem({ label: "foo" }, defaultOptions)
+                .displayLabel,
+        ).toBeUndefined();
+        expect(
+            convertCompletionItem(
+                { label: "foo", filterText: "foo" },
+                defaultOptions,
+            ).displayLabel,
+        ).toBeUndefined();
+    });
+});

--- a/src/__tests__/language-server-client.test.ts
+++ b/src/__tests__/language-server-client.test.ts
@@ -320,8 +320,28 @@ describe("LanguageServerClient", () => {
                     snippetSupport: true,
                     commitCharactersSupport: true,
                     documentationFormat: ["markdown", "plaintext"],
-                    deprecatedSupport: false,
+                    deprecatedSupport: true,
                     preselectSupport: false,
+                    insertReplaceSupport: true,
+                    tagSupport: {
+                        valueSet: [1],
+                    },
+                    resolveSupport: {
+                        properties: [
+                            "documentation",
+                            "detail",
+                            "additionalTextEdits",
+                        ],
+                    },
+                },
+                completionList: {
+                    itemDefaults: [
+                        "commitCharacters",
+                        "editRange",
+                        "insertTextFormat",
+                        "insertTextMode",
+                        "data",
+                    ],
                 },
                 contextSupport: false,
             });

--- a/src/__tests__/language-server-plugin.test.ts
+++ b/src/__tests__/language-server-plugin.test.ts
@@ -26,6 +26,9 @@ vi.mock("../utils.js", () => ({
         return 0;
     }),
     prefixMatch: vi.fn().mockReturnValue(undefined),
+    isCompletionList: vi
+        .fn()
+        .mockImplementation((result) => !Array.isArray(result)),
     formatContents: vi.fn().mockImplementation((contents) => {
         if (typeof contents === "string") return contents;
         if (typeof contents === "object" && contents.value)
@@ -504,6 +507,94 @@ describe("LanguageServerPlugin", () => {
             );
 
             expect(result).toBeNull();
+        });
+
+        const fakeContext = {
+            pos: 0,
+            matchBefore: () => null,
+        } as never;
+        const trigger = {
+            triggerKind: CompletionTriggerKind.Invoked,
+            triggerCharacter: undefined,
+        };
+        // The mocked initialize() resolves with no capabilities and would
+        // overwrite the ones assigned in beforeEach; wait it out and restore
+        const prepareClient = async () => {
+            await mockClient.initializePromise;
+            mockClient.ready = true;
+            mockClient.capabilities = {
+                completionProvider: { resolveProvider: true },
+            };
+        };
+
+        it("disables CodeMirror filtering by default", async () => {
+            await prepareClient();
+            mockClient.textDocumentCompletion = vi.fn().mockResolvedValue({
+                isIncomplete: false,
+                items: [{ label: "foo" }],
+            });
+
+            const result = await plugin.requestCompletion(
+                fakeContext,
+                { line: 0, character: 0 },
+                trigger,
+            );
+
+            expect(result?.filter).toBe(false);
+            expect(result?.validFor).toBeUndefined();
+        });
+
+        it("returns validFor for complete lists when clientSideFiltering is enabled", async () => {
+            await prepareClient();
+            plugin.clientSideFiltering = true;
+            mockClient.textDocumentCompletion = vi.fn().mockResolvedValue({
+                isIncomplete: false,
+                items: [{ label: "foo" }],
+            });
+
+            const result = await plugin.requestCompletion(
+                fakeContext,
+                { line: 0, character: 0 },
+                trigger,
+            );
+
+            expect(result?.filter).toBeUndefined();
+            expect(result?.validFor).toBeInstanceOf(RegExp);
+        });
+
+        it("keeps re-querying incomplete lists even with clientSideFiltering", async () => {
+            await prepareClient();
+            plugin.clientSideFiltering = true;
+            mockClient.textDocumentCompletion = vi.fn().mockResolvedValue({
+                isIncomplete: true,
+                items: [{ label: "foo" }],
+            });
+
+            const result = await plugin.requestCompletion(
+                fakeContext,
+                { line: 0, character: 0 },
+                trigger,
+            );
+
+            expect(result?.filter).toBe(false);
+            expect(result?.validFor).toBeUndefined();
+        });
+
+        it("materializes itemDefaults onto completion items", async () => {
+            await prepareClient();
+            mockClient.textDocumentCompletion = vi.fn().mockResolvedValue({
+                isIncomplete: false,
+                itemDefaults: { commitCharacters: ["."] },
+                items: [{ label: "foo" }],
+            });
+
+            const result = await plugin.requestCompletion(
+                fakeContext,
+                { line: 0, character: 0 },
+                trigger,
+            );
+
+            expect(result?.options[0]?.commitCharacters).toEqual(["."]);
         });
     });
 

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -3,6 +3,8 @@ import type { EditorView } from "@codemirror/view";
 import { describe, expect, it, vi } from "vitest";
 import type * as LSP from "vscode-languageserver-protocol";
 import {
+    isCompletionList,
+    isInsertReplaceEdit,
     isLSPMarkupContent,
     isLSPTextEdit,
     prefixMatch,
@@ -46,6 +48,41 @@ describe("isLSPTextEdit", () => {
     it("should return false for object without range", () => {
         const invalidEdit = { newText: "test" };
         expect(isLSPTextEdit(invalidEdit as LSP.TextEdit)).toBe(false);
+    });
+});
+
+describe("isInsertReplaceEdit", () => {
+    const range: LSP.Range = {
+        start: { line: 0, character: 0 },
+        end: { line: 0, character: 5 },
+    };
+
+    it("should return true for LSP.InsertReplaceEdit", () => {
+        expect(
+            isInsertReplaceEdit({
+                insert: range,
+                replace: range,
+                newText: "test",
+            }),
+        ).toBe(true);
+    });
+
+    it("should return false for a plain TextEdit", () => {
+        expect(isInsertReplaceEdit({ range, newText: "test" })).toBe(false);
+    });
+
+    it("should return false for undefined", () => {
+        expect(isInsertReplaceEdit(undefined)).toBe(false);
+    });
+});
+
+describe("isCompletionList", () => {
+    it("should return true for a CompletionList", () => {
+        expect(isCompletionList({ isIncomplete: false, items: [] })).toBe(true);
+    });
+
+    it("should return false for a bare item array", () => {
+        expect(isCompletionList([{ label: "test" }])).toBe(false);
     });
 });
 

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -182,6 +182,9 @@ function applyLazyAdditionalTextEdits(opts: {
 }): void {
     const { view, originalDoc, mainFrom, mainTo, insertedLength, resolveItem } =
         opts;
+    // Snapshot to detect edits racing the resolve round-trip (Text is
+    // immutable, so identity means unchanged)
+    const docAfterMainEdit = view.state.doc;
     const mapPos = mapThroughReplacement(mainFrom, mainTo, insertedLength);
     resolveItem()
         .then((resolved) => {
@@ -189,18 +192,21 @@ function applyLazyAdditionalTextEdits(opts: {
             if (!edits?.length) {
                 return;
             }
+            // The mapped offsets are only valid against the document as the
+            // main edit left it; drop the edits if the user typed since
+            if (view.state.doc !== docAfterMainEdit) {
+                return;
+            }
             const changes = convertAdditionalTextEdits(
                 originalDoc,
                 edits,
                 mainFrom,
                 mainTo,
-            )
-                .map((change) => ({
-                    ...change,
-                    from: mapPos(change.from),
-                    to: mapPos(change.to),
-                }))
-                .filter((change) => change.to <= view.state.doc.length);
+            ).map((change) => ({
+                ...change,
+                from: mapPos(change.from),
+                to: mapPos(change.to),
+            }));
             if (changes.length === 0) {
                 return;
             }
@@ -335,6 +341,7 @@ export function convertCompletionItem(
         additionalTextEdits,
         insertTextFormat,
         commitCharacters,
+        filterText,
     } = item;
 
     // Resolve at most once; shared by the info panel and apply
@@ -445,6 +452,13 @@ export function convertCompletionItem(
         },
         type: kind ? CompletionItemKindMap[kind]?.toLowerCase() : undefined,
     };
+
+    // CodeMirror matches typed input against `label`, but LSP defines
+    // matching against `filterText`; keep the LSP label for display
+    if (filterText != null && filterText !== label) {
+        completion.label = filterText;
+        completion.displayLabel = label;
+    }
 
     if (commitCharacters?.length) {
         completion.commitCharacters = commitCharacters;

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -1,10 +1,15 @@
 import type { Completion } from "@codemirror/autocomplete";
 import { insertCompletionText, snippet } from "@codemirror/autocomplete";
+import type { Text } from "@codemirror/state";
 import type { EditorView } from "@codemirror/view";
 import type * as LSP from "vscode-languageserver-protocol";
-import { CompletionItemKind } from "vscode-languageserver-protocol";
+import {
+    CompletionItemKind,
+    CompletionItemTag,
+} from "vscode-languageserver-protocol";
 import {
     isEmptyDocumentation,
+    isInsertReplaceEdit,
     isLSPTextEdit,
     posToOffset,
     renderDocumentation,
@@ -13,6 +18,198 @@ import {
 const CompletionItemKindMap = Object.fromEntries(
     Object.entries(CompletionItemKind).map(([key, value]) => [value, key]),
 ) as Record<CompletionItemKind, string>;
+
+/**
+ * A CodeMirror completion with LSP-specific metadata attached.
+ */
+export interface LSPCompletion extends Completion {
+    /** Set when the server marked the item deprecated */
+    deprecated?: boolean;
+}
+
+/**
+ * Whether the server marked the item deprecated, via tags or the legacy
+ * `deprecated` flag.
+ */
+export function isDeprecatedItem(
+    item: Pick<LSP.CompletionItem, "deprecated" | "tags">,
+): boolean {
+    return Boolean(
+        item.deprecated || item.tags?.includes(CompletionItemTag.Deprecated),
+    );
+}
+
+/**
+ * CSS class for a rendered completion option: `cm-deprecated` for items the
+ * server marked deprecated.
+ */
+export function completionOptionClass(completion: Completion): string {
+    return (completion as LSPCompletion).deprecated ? "cm-deprecated" : "";
+}
+
+function isInsertReplaceRange(
+    editRange: LSP.Range | { insert: LSP.Range; replace: LSP.Range },
+): editRange is { insert: LSP.Range; replace: LSP.Range } {
+    return "insert" in editRange;
+}
+
+/**
+ * Applies `CompletionList.itemDefaults` (LSP 3.17) to an item. Item fields
+ * win over defaults; a default `editRange` becomes a per-item `textEdit`
+ * whose text is `textEditText ?? label` (per spec).
+ */
+export function resolveItemDefaults(
+    item: LSP.CompletionItem,
+    defaults: LSP.CompletionList["itemDefaults"],
+): LSP.CompletionItem {
+    if (!defaults) {
+        return item;
+    }
+    const resolved: LSP.CompletionItem = { ...item };
+    if (resolved.commitCharacters == null) {
+        resolved.commitCharacters = defaults.commitCharacters;
+    }
+    if (resolved.insertTextFormat == null) {
+        resolved.insertTextFormat = defaults.insertTextFormat;
+    }
+    if (resolved.insertTextMode == null) {
+        resolved.insertTextMode = defaults.insertTextMode;
+    }
+    if (resolved.data === undefined) {
+        resolved.data = defaults.data;
+    }
+    if (resolved.textEdit == null && defaults.editRange) {
+        const newText = resolved.textEditText ?? resolved.label;
+        resolved.textEdit = isInsertReplaceRange(defaults.editRange)
+            ? {
+                  newText,
+                  insert: defaults.editRange.insert,
+                  replace: defaults.editRange.replace,
+              }
+            : { newText, range: defaults.editRange };
+    }
+    return resolved;
+}
+
+/**
+ * Resolves a completion's primary edit into document offsets and text.
+ * Uses the item's `textEdit` (the `replace` range of an InsertReplaceEdit),
+ * falling back to the token range CodeMirror computed when the server range
+ * is stale.
+ */
+export function resolveMainEdit(
+    doc: Text,
+    item: Pick<LSP.CompletionItem, "textEdit" | "insertText" | "label">,
+    fallbackFrom: number,
+    fallbackTo: number,
+): { from: number; to: number; newText: string } {
+    const { textEdit, insertText, label } = item;
+    let from = fallbackFrom;
+    let to = fallbackTo;
+    let newText = insertText || label;
+    if (textEdit) {
+        const range = isLSPTextEdit(textEdit)
+            ? textEdit.range
+            : isInsertReplaceEdit(textEdit)
+              ? textEdit.replace
+              : undefined;
+        if (range) {
+            newText = textEdit.newText;
+            const start = posToOffset(doc, range.start);
+            const end = posToOffset(doc, range.end);
+            if (start != null && end != null && start <= end) {
+                from = start;
+                to = end;
+            }
+        }
+    }
+    return { from, to, newText };
+}
+
+/**
+ * Converts `additionalTextEdits` into CodeMirror changes against `doc` (the
+ * document the edits refer to), dropping edits that are invalid or overlap
+ * the main edit.
+ */
+export function convertAdditionalTextEdits(
+    doc: Text,
+    edits: readonly LSP.TextEdit[],
+    mainFrom: number,
+    mainTo: number,
+): { from: number; to: number; insert: string }[] {
+    const changes: { from: number; to: number; insert: string }[] = [];
+    for (const edit of edits) {
+        const from = posToOffset(doc, edit.range.start);
+        const to = posToOffset(doc, edit.range.end);
+        if (from == null || to == null || from > to) {
+            continue;
+        }
+        if (to > mainFrom && from < mainTo) {
+            continue;
+        }
+        changes.push({ from, to, insert: edit.newText });
+    }
+    return changes;
+}
+
+/**
+ * Maps positions through a single replacement of `[from, to)` by
+ * `insertedLength` characters. Positions inside the replaced range are
+ * unsupported; drop overlapping edits first.
+ */
+export function mapThroughReplacement(
+    from: number,
+    to: number,
+    insertedLength: number,
+): (pos: number) => number {
+    return (pos) => (pos <= from ? pos : pos - (to - from) + insertedLength);
+}
+
+/**
+ * Resolves the item after the main edit was applied and dispatches any
+ * `additionalTextEdits` it brings (commonly auto-imports), mapping their
+ * pre-completion offsets through the main replacement.
+ */
+function applyLazyAdditionalTextEdits(opts: {
+    view: EditorView;
+    /** The document as it was before the completion was applied */
+    originalDoc: Text;
+    mainFrom: number;
+    mainTo: number;
+    /** Length of the text the main edit inserted */
+    insertedLength: number;
+    resolveItem: () => Promise<LSP.CompletionItem>;
+}): void {
+    const { view, originalDoc, mainFrom, mainTo, insertedLength, resolveItem } =
+        opts;
+    const mapPos = mapThroughReplacement(mainFrom, mainTo, insertedLength);
+    resolveItem()
+        .then((resolved) => {
+            const edits = resolved?.additionalTextEdits;
+            if (!edits?.length) {
+                return;
+            }
+            const changes = convertAdditionalTextEdits(
+                originalDoc,
+                edits,
+                mainFrom,
+                mainTo,
+            )
+                .map((change) => ({
+                    ...change,
+                    from: mapPos(change.from),
+                    to: mapPos(change.to),
+                }))
+                .filter((change) => change.to <= view.state.doc.length);
+            if (changes.length === 0) {
+                return;
+            }
+            view.dispatch({ changes, userEvent: "input.complete" });
+        })
+        .catch((e) => {
+            console.error("Failed to resolve completion item:", e);
+        });
+}
 
 interface ConvertCompletionOptions {
     allowHTMLContent: boolean;
@@ -128,20 +325,26 @@ function convertSnippetToPlainText(snippet: string): string {
 export function convertCompletionItem(
     item: LSP.CompletionItem,
     options: ConvertCompletionOptions,
-): Completion {
+): LSPCompletion {
     const {
         detail,
         labelDetails,
         label,
         kind,
-        textEdit,
-        insertText,
         documentation,
         additionalTextEdits,
         insertTextFormat,
+        commitCharacters,
     } = item;
 
-    const completion: Completion = {
+    // Resolve at most once; shared by the info panel and apply
+    let resolvedItemPromise: Promise<LSP.CompletionItem> | null = null;
+    const resolveItemOnce = () => {
+        resolvedItemPromise ??= options.resolveItem(item);
+        return resolvedItemPromise;
+    };
+
+    const completion: LSPCompletion = {
         label,
         detail: labelDetails?.detail || detail,
         apply(
@@ -152,46 +355,37 @@ export function convertCompletionItem(
         ) {
             const state = view.state;
 
-            // Resolve the main edit range and text. If the server-provided
-            // textEdit range does not resolve to a valid range in the current
-            // document (e.g. it is stale), fall back to the token range
-            // CodeMirror computed.
-            let mainFrom = from;
-            let mainTo = to;
-            let newText = insertText || label;
-            if (textEdit && isLSPTextEdit(textEdit)) {
-                newText = textEdit.newText;
-                const start = posToOffset(state.doc, textEdit.range.start);
-                const end = posToOffset(state.doc, textEdit.range.end);
-                if (start != null && end != null && start <= end) {
-                    mainFrom = start;
-                    mainTo = end;
-                }
-            }
+            const {
+                from: mainFrom,
+                to: mainTo,
+                newText: mainText,
+            } = resolveMainEdit(state.doc, item, from, to);
+            let newText = mainText;
 
             // additionalTextEdits refer to the document as it was before the
-            // completion is applied, so resolve their offsets now. Skip edits
-            // that are invalid or overlap the main edit.
-            const additionalChanges: {
-                from: number;
-                to: number;
-                insert: string;
-            }[] = [];
-            for (const edit of additionalTextEdits ?? []) {
-                const editFrom = posToOffset(state.doc, edit.range.start);
-                const editTo = posToOffset(state.doc, edit.range.end);
-                if (editFrom == null || editTo == null || editFrom > editTo) {
-                    continue;
+            // completion is applied, so resolve their offsets now
+            const additionalChanges = convertAdditionalTextEdits(
+                state.doc,
+                additionalTextEdits ?? [],
+                mainFrom,
+                mainTo,
+            );
+
+            const scheduleLazyAdditionalTextEdits = (
+                insertedLength: number,
+            ) => {
+                if (additionalTextEdits || !options.hasResolveProvider) {
+                    return;
                 }
-                if (editTo > mainFrom && editFrom < mainTo) {
-                    continue;
-                }
-                additionalChanges.push({
-                    from: editFrom,
-                    to: editTo,
-                    insert: edit.newText,
+                applyLazyAdditionalTextEdits({
+                    view,
+                    originalDoc: state.doc,
+                    mainFrom,
+                    mainTo,
+                    insertedLength,
+                    resolveItem: resolveItemOnce,
                 });
-            }
+            };
 
             if (
                 insertTextFormat === InsertTextFormat.Snippet &&
@@ -207,8 +401,14 @@ export function convertCompletionItem(
                     snippetFrom = changeSet.mapPos(snippetFrom, 1);
                     snippetTo = changeSet.mapPos(snippetTo, 1);
                 }
+                const lengthBeforeSnippet = view.state.doc.length;
                 const applySnippet = snippet(convertSnippet(newText));
                 applySnippet(view, null, snippetFrom, snippetTo);
+                scheduleLazyAdditionalTextEdits(
+                    view.state.doc.length -
+                        lengthBeforeSnippet +
+                        (snippetTo - snippetFrom),
+                );
                 return;
             }
 
@@ -222,6 +422,7 @@ export function convertCompletionItem(
                 view.dispatch(
                     insertCompletionText(state, newText, mainFrom, mainTo),
                 );
+                scheduleLazyAdditionalTextEdits(newText.length);
                 return;
             }
 
@@ -245,6 +446,14 @@ export function convertCompletionItem(
         type: kind ? CompletionItemKindMap[kind]?.toLowerCase() : undefined,
     };
 
+    if (commitCharacters?.length) {
+        completion.commitCharacters = commitCharacters;
+    }
+
+    if (isDeprecatedItem(item)) {
+        completion.deprecated = true;
+    }
+
     const createDocumentationDom = (
         content: NonNullable<LSP.CompletionItem["documentation"]>,
     ) => {
@@ -258,10 +467,10 @@ export function convertCompletionItem(
     };
 
     // Support lazy loading of documentation through completionItem/resolve
-    if (options.hasResolveProvider && options.resolveItem) {
+    if (options.hasResolveProvider) {
         completion.info = async () => {
             try {
-                const resolved = await options.resolveItem?.(item);
+                const resolved = await resolveItemOnce();
                 const content = resolved?.documentation || documentation;
                 if (!content || isEmptyDocumentation(content)) {
                     return null;
@@ -288,6 +497,8 @@ export function sortCompletionItems(
     items: LSP.CompletionItem[],
     matchBefore: string | undefined,
     language: string,
+    // false keeps every item, for when CodeMirror filters client-side
+    filter = true,
 ): LSP.CompletionItem[] {
     const sortFunctions = [
         matchBefore ? prefixSortCompletion(matchBefore) : nameSortCompletion,
@@ -297,7 +508,7 @@ export function sortCompletionItems(
     let result = items;
 
     // If we found a token that matches our completion pattern
-    if (matchBefore) {
+    if (matchBefore && filter) {
         const word = matchBefore.toLowerCase();
         // Only filter and sort for word characters
         if (/^\w+$/.test(word)) {

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -263,6 +263,14 @@ export interface LanguageServerOptions extends FeatureOptions {
     completionMatchBefore?: RegExp;
 
     /**
+     * When the server returns a complete (`isIncomplete: false`) completion
+     * list, let CodeMirror filter it client-side as the user types instead
+     * of re-querying the server on every keystroke.
+     * @default false
+     */
+    clientSideFiltering?: boolean;
+
+    /**
      * Whether to send incremental changes to the language server.
      * @default true
      */
@@ -463,8 +471,29 @@ export class LanguageServerClient {
                         snippetSupport: true,
                         commitCharactersSupport: true,
                         documentationFormat: ["markdown", "plaintext"],
-                        deprecatedSupport: false,
+                        deprecatedSupport: true,
                         preselectSupport: false,
+                        insertReplaceSupport: true,
+                        tagSupport: {
+                            // CompletionItemTag.Deprecated
+                            valueSet: [1],
+                        },
+                        resolveSupport: {
+                            properties: [
+                                "documentation",
+                                "detail",
+                                "additionalTextEdits",
+                            ],
+                        },
+                    },
+                    completionList: {
+                        itemDefaults: [
+                            "commitCharacters",
+                            "editRange",
+                            "insertTextFormat",
+                            "insertTextMode",
+                            "data",
+                        ],
                     },
                     contextSupport: false,
                 },

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -34,7 +34,12 @@ import {
 import type { PluginValue, ViewUpdate } from "@codemirror/view";
 import type * as LSP from "vscode-languageserver-protocol";
 import type { PublishDiagnosticsParams } from "vscode-languageserver-protocol";
-import { convertCompletionItem, sortCompletionItems } from "./completion.js";
+import {
+    completionOptionClass,
+    convertCompletionItem,
+    resolveItemDefaults,
+    sortCompletionItems,
+} from "./completion.js";
 import { documentUri, languageId } from "./config.js";
 import {
     type DefinitionResult,
@@ -46,6 +51,7 @@ import {
 } from "./lsp.js";
 import {
     eventsFromChangeSet,
+    isCompletionList,
     isEmptyDocumentation,
     offsetToPos,
     posToOffset,
@@ -171,6 +177,11 @@ export class LanguageServerPlugin implements PluginValue {
      */
     public useSnippetOnCompletion: boolean;
     /**
+     * Whether complete (`isIncomplete: false`) completion lists are filtered
+     * client-side by CodeMirror instead of re-querying the server.
+     */
+    public clientSideFiltering: boolean;
+    /**
      * Whether to send incremental changes to the language server.
      */
     public sendIncrementalChanges: boolean;
@@ -199,6 +210,7 @@ export class LanguageServerPlugin implements PluginValue {
         sendIncrementalChanges?: boolean;
         allowHTMLContent?: boolean;
         useSnippetOnCompletion?: boolean;
+        clientSideFiltering?: boolean;
         onGoToDefinition?: (result: DefinitionResult) => void;
         markdownRenderer?: (markdown: string) => string;
     }) {
@@ -211,6 +223,7 @@ export class LanguageServerPlugin implements PluginValue {
             sendIncrementalChanges = true,
             allowHTMLContent = false,
             useSnippetOnCompletion = false,
+            clientSideFiltering = false,
             onGoToDefinition,
             markdownRenderer = renderMarkdown,
         } = opts;
@@ -222,6 +235,7 @@ export class LanguageServerPlugin implements PluginValue {
         this.view = view;
         this.allowHTMLContent = allowHTMLContent;
         this.useSnippetOnCompletion = useSnippetOnCompletion;
+        this.clientSideFiltering = clientSideFiltering;
         this.sendIncrementalChanges = sendIncrementalChanges;
         this.featureOptions = featureOptions;
         this.onGoToDefinition = onGoToDefinition;
@@ -543,7 +557,17 @@ export class LanguageServerPlugin implements PluginValue {
             return null;
         }
 
-        const items = "items" in result ? result.items : result;
+        const completionList: LSP.CompletionList = isCompletionList(result)
+            ? result
+            : { isIncomplete: false, items: result };
+
+        const items = completionList.items.map((item) =>
+            resolveItemDefaults(item, completionList.itemDefaults),
+        );
+
+        // Incomplete lists must always be re-queried on further input
+        const useClientSideFiltering =
+            this.clientSideFiltering && !completionList.isIncomplete;
 
         // Match is undefined if there are no common prefixes
         const match = prefixMatch(items);
@@ -560,6 +584,7 @@ export class LanguageServerPlugin implements PluginValue {
             items,
             token?.text,
             this.languageId,
+            !useClientSideFiltering,
         );
 
         // If we found a token that matches our completion pattern
@@ -580,6 +605,14 @@ export class LanguageServerPlugin implements PluginValue {
                 ),
             });
         });
+
+        if (useClientSideFiltering) {
+            return {
+                from: pos,
+                options,
+                validFor: /^\w*$/,
+            };
+        }
 
         return {
             from: pos,
@@ -1486,6 +1519,7 @@ export function languageServerWithClient(options: LanguageServerOptions) {
                 sendIncrementalChanges: options.sendIncrementalChanges,
                 allowHTMLContent: options.allowHTMLContent,
                 useSnippetOnCompletion: options.useSnippetOnCompletion,
+                clientSideFiltering: options.clientSideFiltering,
                 onGoToDefinition: options.onGoToDefinition,
                 markdownRenderer: options.markdownRenderer,
             }),
@@ -1701,9 +1735,24 @@ export function languageServerWithClient(options: LanguageServerOptions) {
 
     // Only add autocompletion if enabled
     if (featuresOptions.completionEnabled) {
+        const userOptionClass = options.completionConfig?.optionClass;
         extensions.push(
+            // Hosts can override via `.cm-tooltip-autocomplete li.cm-deprecated`
+            EditorView.baseTheme({
+                ".cm-tooltip-autocomplete li.cm-deprecated .cm-completionLabel":
+                    {
+                        textDecoration: "line-through",
+                    },
+            }),
             autocompletion({
                 ...options.completionConfig,
+                optionClass: (completion) =>
+                    [
+                        completionOptionClass(completion),
+                        userOptionClass?.(completion) ?? "",
+                    ]
+                        .filter(Boolean)
+                        .join(" "),
                 override: [
                     /**
                      * Completion source function that handles LSP-based autocompletion

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -215,6 +215,21 @@ export function isLSPTextEdit(
     return (textEdit as LSP.TextEdit)?.range !== undefined;
 }
 
+export function isCompletionList(
+    result: LSP.CompletionItem[] | LSP.CompletionList,
+): result is LSP.CompletionList {
+    return !Array.isArray(result);
+}
+
+export function isInsertReplaceEdit(
+    textEdit?: LSP.TextEdit | LSP.InsertReplaceEdit,
+): textEdit is LSP.InsertReplaceEdit {
+    return (
+        (textEdit as LSP.InsertReplaceEdit)?.insert !== undefined &&
+        (textEdit as LSP.InsertReplaceEdit)?.replace !== undefined
+    );
+}
+
 export function isLSPMarkupContent(
     contents: LSP.MarkupContent | LSP.MarkedString | LSP.MarkedString[],
 ): contents is LSP.MarkupContent {


### PR DESCRIPTION
## Summary

Closes several LSP completion spec gaps in `convertCompletionItem` / `requestCompletion`:

- **`CompletionList.itemDefaults` (LSP 3.17)** — `resolveItemDefaults` materializes list-level defaults (`commitCharacters`, `insertTextFormat`, `insertTextMode`, `data`, `editRange`) onto each item; item fields win. A default `editRange` (both `Range` and `{insert, replace}` shapes) becomes a per-item `textEdit` using `textEditText ?? label`.
- **`InsertReplaceEdit`** — previously fell through to plain `insertText`/`label` insertion; now applied using its `replace` range, with the same stale-range fallback as plain TextEdits.
- **Capabilities** — now advertises `insertReplaceSupport`, `deprecatedSupport`, `tagSupport: { valueSet: [Deprecated] }`, `resolveSupport: [documentation, detail, additionalTextEdits]`, and `completionList.itemDefaults`.
- **`commitCharacters`** — passed through to CodeMirror's `Completion.commitCharacters`, so the advertised `commitCharactersSupport` is now honored.
- **Deprecated items** — get a `cm-deprecated` class (strikethrough via `baseTheme`, override documented in README); composes with a user-provided `optionClass`.
- **Lazy `additionalTextEdits`** — auto-import edits that only arrive via `completionItem/resolve` are now applied after the main edit, with offsets mapped through the replacement. Resolve is memoized per item (shared by the info panel and apply).
- **`clientSideFiltering` option (opt-in, default off)** — complete (`isIncomplete: false`) lists return `validFor: /^\w*$/` so CodeMirror filters client-side instead of re-querying the server per keystroke. Incomplete lists always re-query.

Note: the spec's filter-by-`filterText` / order-by-`sortText` separation was already implemented in `prefixSortCompletion`, so no change there.

Extracted pure helpers (`resolveMainEdit`, `convertAdditionalTextEdits`, `mapThroughReplacement`, `isDeprecatedItem`, `completionOptionClass`) and type guards (`isCompletionList`, `isInsertReplaceEdit`) keep `apply` small and unit-testable.

## Testing

- 46 new unit tests: itemDefaults merge precedence and both editRange shapes, InsertReplaceEdit apply + stale-range fallback, lazy-resolve edits (plain, snippet, no-double-apply, overlap-skip), deprecated/commitCharacters metadata, `validFor`/`filter` gating, guard and mapping helpers
- `pnpm test` (404 passed), `pnpm run typecheck`, `pnpm run lint:ci`, `pnpm run build:demo` all green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes key LSP completion gaps: supports list-level defaults, insert/replace edits, commit characters, deprecated items, lazy additionalTextEdits, and client-side filtering. Improves correctness and reduces unnecessary server calls.

- **New Features**
  - Apply `CompletionList.itemDefaults` to items (including default `editRange` -> per-item `textEdit` via `textEditText ?? label`).
  - Support `InsertReplaceEdit` using its `replace` range with safe fallback to the token range.
  - Advertise capabilities: `insertReplaceSupport`, `deprecatedSupport`, `tagSupport: { Deprecated }`, `resolveSupport: [documentation, detail, additionalTextEdits]`, and `completionList.itemDefaults`.
  - Pass through `commitCharacters` to CodeMirror completions.
  - Mark deprecated items with `cm-deprecated` (composes with user `optionClass`; base theme adds strikethrough; override shown in README).
  - Lazy `additionalTextEdits` from `completionItem/resolve`: apply after the main edit, map offsets through the replacement, skip overlaps, memoize per item, and drop if the doc changed during resolve.
  - Match against `filterText` and keep the LSP label in `displayLabel` so client-side filtering follows LSP semantics.
  - Add `clientSideFiltering` (opt-in) for complete lists: return `validFor` to let CodeMirror filter locally; incomplete lists still re-query. README updated.

- **Refactors**
  - Extract helpers: `resolveMainEdit`, `convertAdditionalTextEdits`, `mapThroughReplacement`, `resolveItemDefaults`, `isDeprecatedItem`, `completionOptionClass`; type guards: `isCompletionList`, `isInsertReplaceEdit`. Expanded tests cover defaults precedence, insert/replace apply, lazy edits (overlap/race handling), metadata, and filtering behavior.

<sup>Written for commit 7d76bbd82e9ca125ba4e33e2645bacf595dfad35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marimo-team/codemirror-languageserver/pull/79?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

