### PR TITLE
demo: richer Python/TS samples, reorder tabs, build ty in CI

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -12,6 +12,11 @@ jobs:
     name: 🏗️ Build
     runs-on: ubuntu-latest
 
+    # Pin the ruff revision ty_wasm is built from so the deployed demo is
+    # reproducible and matches the ty API demo/python/tyServer.ts targets.
+    env:
+      RUFF_REF: e212348aedf922c63ee6b54e715258ba37573b37
+
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
@@ -24,8 +29,35 @@ jobs:
           node-version: 24
           cache: pnpm
 
+      # ty_wasm isn't published to npm, so build it from source. Without this the
+      # demo silently falls back to Ruff-only (see demo/python/worker.ts).
+      - name: ⎔ Setup Rust
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: ⎔ Setup wasm-pack
+        uses: jetli/wasm-pack-action@0d096b08b4e5a7de8c28de67e11e945404e9eefa # v0.4.0
+
+      # Cache the ruff checkout + cargo/target so the expensive Rust build only
+      # pays full cost when RUFF_REF changes.
+      - name: 💾 Cache ty_wasm build
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            .cache/ruff
+          key: ty-wasm-${{ runner.os }}-${{ env.RUFF_REF }}
+
       - name: 📥 Install dependencies
         run: pnpm install --ignore-scripts --frozen-lockfile
+
+      # Non-fatal: if the Rust build fails, the demo still deploys Ruff-only
+      # (demo/python/worker.ts falls back when ty_wasm is absent).
+      - name: 🦀 Build ty_wasm
+        continue-on-error: true
+        run: pnpm build:ty-wasm
 
       - name: 🛠️ Build project
         run: pnpm build:demo

--- a/demo/demos.ts
+++ b/demo/demos.ts
@@ -10,7 +10,7 @@ export interface Demo {
 }
 
 export const DEMOS: Demo[] = [
-    { id: "mock", label: "Mock · in-memory", mount: mountMockDemo },
-    { id: "python", label: "Python · Ruff", mount: mountPythonDemo },
+    { id: "python", label: "Python · Ruff + ty", mount: mountPythonDemo },
     { id: "typescript", label: "TypeScript · vfs", mount: mountTypeScriptDemo },
+    { id: "mock", label: "Mock · in-memory", mount: mountMockDemo },
 ];

--- a/demo/python/pythonDemo.ts
+++ b/demo/python/pythonDemo.ts
@@ -8,17 +8,24 @@ import { createWorkerClient } from "../shared/workerTransport";
 
 const DOCUMENT_URI = "file:///main.py";
 
-const SAMPLE = `import os
-import sys
+const SAMPLE = `# Python · Ruff (lint + format) + ty (types) — both WASM, in a Web Worker
+# Hover a squiggle for a quick-fix · "Fix all" · "Format document"
+
+import os                      # unused import → Ruff F401
+import sys                     # unused import → "Fix all" removes both
+from typing import List
 
 
 def greet(name: str) -> str:
+    greeting = "Hi"            # F841: local assigned but never used
     return "Hello, " + name
 
 
-# Ruff flags the unused imports above; ty flags the type error below.
-message: int = greet("world")
-print( message )
+message: int = greet("world")  # ty: str is not assignable to int
+
+items: List[int] = [1, 2, 3]
+print( items )                 # extra spaces → "Format document" tidies them
+print(mesage)                  # Ruff F821: undefined name (typo of "message")
 `;
 
 // Python editor backed by Ruff (and ty, when its WASM build is vendored in),
@@ -27,10 +34,11 @@ export function mountPythonDemo(container: HTMLElement): () => void {
     const hint = document.createElement("p");
     hint.className = "demo-hint";
     hint.innerHTML =
-        "Backed by <code>@astral-sh/ruff-wasm-web</code> (lint + format) in a " +
-        "Web Worker, plus <code>ty</code> type-checking when built via " +
-        "<code>pnpm build:ty-wasm</code>. Hover a diagnostic for quick-fix, " +
-        "<em>Fix all</em>, and <em>Format document</em> actions.";
+        "Backed by <code>@astral-sh/ruff-wasm-web</code> (lint + format) and " +
+        "<code>ty</code> (type-checking), both WASM in a Web Worker. Hover a " +
+        "diagnostic for quick-fix, <em>Fix all</em>, and <em>Format document</em> " +
+        "actions. Locally, run <code>pnpm build:ty-wasm</code> to enable ty; " +
+        "the deployed demo builds it in CI.";
     container.appendChild(hint);
 
     const worker = new Worker(new URL("./worker.ts", import.meta.url), {

--- a/demo/typescript/tsDemo.ts
+++ b/demo/typescript/tsDemo.ts
@@ -8,28 +8,32 @@ import { createWorkerClient } from "../shared/workerTransport";
 
 const DOCUMENT_URI = "file:///index.ts";
 
-const SAMPLE = `// TypeScript running entirely in your browser (typescript + @typescript/vfs).
-// Try these features:
-//  - Hover over 'greet' or 'user' to see inferred types
-//  - Type 'user.' for completions
-//  - Ctrl/Cmd+Click 'greet' to jump to its definition
-//  - Put the cursor inside greet(...) for signature help
-//  - Press F2 on 'user' to rename it
-//  - The line below has a type error on purpose
+const SAMPLE = `// TypeScript · runs entirely in your browser (typescript + @typescript/vfs)
+// hover · go-to-def (Ctrl/Cmd+Click) · completions (Ctrl/Cmd+Space) · F2 rename
 
 interface User {
     name: string;
     age: number;
 }
 
-function greet(user: User): string {
+/** @deprecated Use greet() instead. */
+function hi(user: User): string {          // deprecated → struck through on use
+    return "hi " + user.name;
+}
+
+function greet(user: User): string {       // hover for its type · go-to-def target
+    const unused = "never read";           // unused local variable → diagnostic
     return \`Hello, \${user.name} (\${user.age})\`;
 }
 
-const user: User = { name: "Ada", age: 36 };
-console.log(greet(user));
+const ada: User = { name: "Ada", age: 36 };
 
-const wrong: number = "not a number";
+greet(ada);        // put the cursor inside (…) for signature help; F2 renames \`ada\`
+hi(ada);           // deprecated call → struck through
+
+ada.name;          // type \`ada.\` and press Ctrl/Cmd+Space for completions
+
+const total: number = "oops";     // type error: string is not assignable to number
 `;
 
 /**

--- a/demo/typescript/tsServer.ts
+++ b/demo/typescript/tsServer.ts
@@ -4,6 +4,7 @@ import type * as LSP from "vscode-languageserver-protocol";
 import {
     CompletionItemKind,
     DiagnosticSeverity,
+    DiagnosticTag,
     TextDocumentSyncKind,
 } from "vscode-languageserver-protocol";
 
@@ -60,6 +61,9 @@ export class TsServer {
         const raw = [
             ...this.ls.getSyntacticDiagnostics(this.fileName),
             ...this.ls.getSemanticDiagnostics(this.fileName),
+            // Suggestion diagnostics carry @deprecated markers (and unused
+            // hints), letting the demo showcase deprecated + unnecessary tags.
+            ...this.ls.getSuggestionDiagnostics(this.fileName),
         ];
         return {
             uri,
@@ -231,6 +235,13 @@ export class TsServer {
     private toLspDiagnostic(diagnostic: ts.Diagnostic): LSP.Diagnostic {
         const start = diagnostic.start ?? 0;
         const length = diagnostic.length ?? 0;
+        const tags: LSP.DiagnosticTag[] = [];
+        if (diagnostic.reportsUnnecessary) {
+            tags.push(DiagnosticTag.Unnecessary);
+        }
+        if (diagnostic.reportsDeprecated) {
+            tags.push(DiagnosticTag.Deprecated);
+        }
         return {
             range: this.rangeFromSpan(this.fileName, { start, length }),
             message: ts.flattenDiagnosticMessageText(
@@ -239,6 +250,7 @@ export class TsServer {
             ),
             code: diagnostic.code,
             severity: mapCategory(diagnostic.category),
+            tags: tags.length > 0 ? tags : undefined,
             source: "ts",
         };
     }

--- a/demo/typescript/worker.ts
+++ b/demo/typescript/worker.ts
@@ -18,6 +18,8 @@ const COMPILER_OPTIONS: ts.CompilerOptions = {
     module: ts.ModuleKind.ESNext,
     moduleResolution: ts.ModuleResolutionKind.Bundler,
     strict: true,
+    // Surface unused locals as diagnostics so the demo can show them off.
+    noUnusedLocals: true,
 };
 
 // Building the environment fetches the TypeScript lib .d.ts files from a CDN


### PR DESCRIPTION
Improves the demo across three fronts.

## 1. Richer samples (Python + TypeScript)
Rewrote both editor samples to concisely showcase many LSP features, one per line with terse inline comments.

**Python** (Ruff + ty):
- unused imports (`F401`) → drives *Fix all*
- unused local (`F841`)
- type error via **ty** (`str` → `int`) — fires in deploy where ty is built
- extra spacing tidied by *Format document*
- undefined name (`F821`)

**TypeScript** (vfs):
- `@deprecated` call (struck through)
- unused local variable
- type error (`string` not assignable to `number`)
- plus existing hover / go-to-def / completions / signature-help / rename

To make unused/deprecated light up, enabled `noUnusedLocals` and pulled in `getSuggestionDiagnostics`, mapping `Unnecessary`/`Deprecated` diagnostic tags.

## 2. Tab order
Python first, TypeScript, Mock last.

## 3. `ty` in the deployed demo
`ty_wasm` isn't on npm and was never built/committed, so the deployed glob resolved empty and silently fell back to Ruff-only. The demo CI now builds it:
- adds Rust toolchain + `wasm-pack`, runs `pnpm build:ty-wasm` before `build:demo`
- pins `RUFF_REF` to the ruff `main` SHA the `tyServer.ts` wrapper targets (reproducible)
- caches the ruff checkout + cargo/target keyed on `RUFF_REF`
- `continue-on-error: true` so a Rust build failure still deploys the demo Ruff-only (runtime `loadTy` try/catch is the second safety net)

Note: the first deploy after this lands will be slow (full ruff compile); cached thereafter.

## Verification
`typecheck`, `lint:ci`, and `build:demo` all pass; `demo.yml` is valid YAML. Both tabs were exercised in a headless browser — tab order, diagnostics (4 Python, 3 TS markers), deprecated strike-through, and type error all confirmed rendering.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Richer Python and TypeScript demos that showcase key LSP features, reordered tabs, and a CI build for `ty_wasm` so the deployed demo includes `ty` type-checking. Previously the deploy fell back to Ruff-only; CI now builds and caches `ty_wasm`.

- New Features
  - Python sample: `@astral-sh/ruff-wasm-web` (lint/format) + `ty` (types) with unused imports (`F401`), unused local (`F841`), type mismatch, format fix, and undefined name (`F821`); quick-fix, Fix all, and Format actions.
  - TypeScript sample (`typescript` + `@typescript/vfs`): deprecated call (strikethrough), unused local, and a type error; enables `noUnusedLocals` and includes suggestion diagnostics with `Deprecated`/`Unnecessary` tags.
  - Tabs reordered: Python, TypeScript, Mock.

- CI/Deployment
  - Build `ty_wasm` from source with Rust + `wasm-pack` before `pnpm build:demo`; pin `RUFF_REF` for reproducible builds.
  - Cache cargo/ruff by `RUFF_REF`; continue-on-error so a Rust build failure still deploys Ruff-only.

<sup>Written for commit 2fbefa127c41a1dd861123d96f2c9b26cceb0836. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marimo-team/codemirror-languageserver/pull/80?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

