### PR TITLE
refactor: drop @open-rpc/client-js for a purpose-built JSON-RPC layer

### DIFF
--- a/demo/mock/mockDemo.ts
+++ b/demo/mock/mockDemo.ts
@@ -69,29 +69,47 @@ class MockTransport implements Transport {
             }
         };
 
-        switch (message.method) {
-            case "initialize":
-                return reply(server.initialize());
-            case "textDocument/didOpen":
-                return void server.didOpenTextDocument(params);
-            case "textDocument/didChange":
-                return void server.didChangeTextDocument(params);
-            case "textDocument/completion":
-                return reply(await server.completion(params));
-            case "completionItem/resolve":
-                return reply(await server.completionResolve(params));
-            case "textDocument/hover":
-                return reply(await server.hover(params));
-            case "textDocument/definition":
-                return reply(await server.definition(params));
-            case "textDocument/prepareRename":
-                return reply(await server.prepareRename(params));
-            case "textDocument/rename":
-                return reply(await server.rename(params));
-            case "textDocument/codeAction":
-                return reply(await server.codeAction(params));
-            case "textDocument/signatureHelp":
-                return reply(await server.signatureHelp(params));
+        try {
+            switch (message.method) {
+                case "initialize":
+                    return reply(server.initialize());
+                case "textDocument/didOpen":
+                    return void server.didOpenTextDocument(params);
+                case "textDocument/didChange":
+                    return void server.didChangeTextDocument(params);
+                case "textDocument/completion":
+                    return reply(await server.completion(params));
+                case "completionItem/resolve":
+                    return reply(await server.completionResolve(params));
+                case "textDocument/hover":
+                    return reply(await server.hover(params));
+                case "textDocument/definition":
+                    return reply(await server.definition(params));
+                case "textDocument/prepareRename":
+                    return reply(await server.prepareRename(params));
+                case "textDocument/rename":
+                    return reply(await server.rename(params));
+                case "textDocument/codeAction":
+                    return reply(await server.codeAction(params));
+                case "textDocument/signatureHelp":
+                    return reply(await server.signatureHelp(params));
+            }
+        } catch (error) {
+            // Settle failed requests with a JSON-RPC error instead of letting
+            // them hang until the client's timeout.
+            if (id !== undefined) {
+                this.emit({
+                    jsonrpc: "2.0",
+                    id,
+                    error: {
+                        code: -32603,
+                        message:
+                            error instanceof Error
+                                ? error.message
+                                : String(error),
+                    },
+                });
+            }
         }
     }
 }

--- a/demo/mock/mockDemo.ts
+++ b/demo/mock/mockDemo.ts
@@ -2,165 +2,97 @@ import { javascript } from "@codemirror/lang-javascript";
 import { lintGutter } from "@codemirror/lint";
 import { EditorState } from "@codemirror/state";
 import { EditorView, tooltips } from "@codemirror/view";
-import type {
-    IJSONRPCData,
-    IJSONRPCNotification,
-    IJSONRPCResponse,
-    JSONRPCRequestData,
-} from "@open-rpc/client-js/build/Request";
-import { Transport } from "@open-rpc/client-js/build/transports/Transport";
 import { basicSetup } from "codemirror";
-import { LanguageServerClient, languageServerWithClient } from "../../src";
+import {
+    type JSONRPCMessage,
+    LanguageServerClient,
+    type Transport,
+    languageServerWithClient,
+} from "../../src";
 import { MockLSPServer } from "../mockLSP";
 
-// Mock WebSocket-like bridge to the in-memory LSP server.
-class MockWebSocket {
-    private server: MockLSPServer;
-    private onMessageCallback?: (data: IJSONRPCResponse) => void;
-    private onNotificationCallback?: (data: IJSONRPCNotification) => void;
-    private onErrorCallback?: (data: IJSONRPCNotification) => void;
+/**
+ * A {@link Transport} that routes JSON-RPC frames to an in-memory
+ * {@link MockLSPServer} and delivers its results (and diagnostics) back to the
+ * client. Requests are dispatched by method; notifications with no matching
+ * handler are simply ignored.
+ */
+class MockTransport implements Transport {
+    private readonly handlers = new Set<(message: JSONRPCMessage) => void>();
 
-    constructor(server: MockLSPServer) {
-        this.server = server;
-        this.server.setOnDiagnostics((params) => {
-            if (this.onNotificationCallback) {
-                this.onNotificationCallback({
-                    jsonrpc: "2.0",
-                    method: "textDocument/publishDiagnostics",
-                    params,
-                });
-            }
+    constructor(private readonly server: MockLSPServer) {
+        server.setOnDiagnostics((params) => {
+            this.emit({
+                jsonrpc: "2.0",
+                method: "textDocument/publishDiagnostics",
+                params,
+            });
         });
     }
 
-    send(data: IJSONRPCData) {
-        const request = data;
-        const { method, id: _id, params } = request.request;
-        // biome-ignore lint/suspicious/noExplicitAny: RPC params are dynamic.
-        const anyParams = params as any;
-        const id = _id ?? "_";
-
-        if (method === "initialize") {
-            return this.respond(id, this.server.initialize());
-        }
-        if (method === "textDocument/didOpen") {
-            return this.server.didOpenTextDocument(anyParams);
-        }
-        if (method === "textDocument/didChange") {
-            return this.server.didChangeTextDocument(anyParams);
-        }
-        if (method === "textDocument/completion") {
-            return this.server
-                .completion(anyParams)
-                .then((result) => this.respond(id, result));
-        }
-        if (method === "completionItem/resolve") {
-            return this.server
-                .completionResolve(anyParams)
-                .then((result) => this.respond(id, result));
-        }
-        if (method === "textDocument/hover") {
-            return this.server
-                .hover(anyParams)
-                .then((result) => this.respond(id, result));
-        }
-        if (method === "textDocument/definition") {
-            return this.server
-                .definition(anyParams)
-                .then((result) => this.respond(id, result));
-        }
-        if (method === "textDocument/prepareRename") {
-            return this.server
-                .prepareRename(anyParams)
-                .then((result) => this.respond(id, result));
-        }
-        if (method === "textDocument/rename") {
-            return this.server
-                .rename(anyParams)
-                .then((result) => this.respond(id, result));
-        }
-        if (method === "textDocument/codeAction") {
-            return this.server
-                .codeAction(anyParams)
-                .then((result) => this.respond(id, result));
-        }
-        if (method === "textDocument/signatureHelp") {
-            return this.server
-                .signatureHelp(anyParams)
-                .then((result) => this.respond(id, result));
-        }
-    }
-
-    addEventListener(
-        event: string,
-        callback: (data: IJSONRPCResponse | IJSONRPCNotification) => void,
-    ) {
-        if (event === "notification") {
-            this.onNotificationCallback = callback;
-        }
-        if (event === "error") {
-            this.onErrorCallback = callback;
-        }
-        if (event === "message") {
-            this.onMessageCallback = callback;
-        }
-    }
-
-    private respond(id: string | number, result: IJSONRPCResponse["result"]) {
-        const body: IJSONRPCResponse = {
-            jsonrpc: "2.0",
-            id,
-            result,
-        };
-        if (this.onMessageCallback) {
-            this.onMessageCallback(body);
-        }
-        return body;
-    }
-}
-
-class MockTransport extends Transport {
-    private callbacks: Map<
-        string,
-        ((data: IJSONRPCResponse | IJSONRPCNotification) => void)[]
-    > = new Map();
-
-    constructor(private socket: MockWebSocket) {
-        super();
-    }
-
-    connect() {
+    connect(): Promise<void> {
         return Promise.resolve();
     }
 
-    send(data: IJSONRPCData) {
-        return this.socket.send(data);
+    send(message: JSONRPCMessage): void {
+        void this.dispatch(message);
     }
 
-    subscribe(
-        event: string,
-        callback: (data: IJSONRPCResponse | IJSONRPCNotification) => void,
-    ) {
-        const callbacks = this.callbacks.get(event) || [];
-        callbacks.push(callback);
-        this.callbacks.set(event, callbacks);
-        this.socket.addEventListener(event, (data) => {
-            for (const cb of callbacks) {
-                cb(data);
-            }
-        });
+    onMessage(handler: (message: JSONRPCMessage) => void): () => void {
+        this.handlers.add(handler);
+        return () => {
+            this.handlers.delete(handler);
+        };
     }
 
-    async sendData(data: JSONRPCRequestData) {
-        const body = await this.socket.send(data as IJSONRPCData);
-        if (body) {
-            return "result" in body ? body.result : undefined;
+    close(): void {
+        this.handlers.clear();
+    }
+
+    private emit(message: JSONRPCMessage): void {
+        for (const handler of this.handlers) {
+            handler(message);
         }
-        return body;
     }
 
-    close() {
-        this.callbacks.clear();
+    private async dispatch(message: JSONRPCMessage): Promise<void> {
+        if (!("method" in message)) {
+            return; // responses from the client (server requests) are ignored
+        }
+        const server = this.server;
+        // biome-ignore lint/suspicious/noExplicitAny: RPC params are dynamic.
+        const params = (message as any).params;
+        const id = "id" in message ? message.id : undefined;
+        const reply = (result: unknown) => {
+            if (id !== undefined) {
+                this.emit({ jsonrpc: "2.0", id, result });
+            }
+        };
+
+        switch (message.method) {
+            case "initialize":
+                return reply(server.initialize());
+            case "textDocument/didOpen":
+                return void server.didOpenTextDocument(params);
+            case "textDocument/didChange":
+                return void server.didChangeTextDocument(params);
+            case "textDocument/completion":
+                return reply(await server.completion(params));
+            case "completionItem/resolve":
+                return reply(await server.completionResolve(params));
+            case "textDocument/hover":
+                return reply(await server.hover(params));
+            case "textDocument/definition":
+                return reply(await server.definition(params));
+            case "textDocument/prepareRename":
+                return reply(await server.prepareRename(params));
+            case "textDocument/rename":
+                return reply(await server.rename(params));
+            case "textDocument/codeAction":
+                return reply(await server.codeAction(params));
+            case "textDocument/signatureHelp":
+                return reply(await server.signatureHelp(params));
+        }
     }
 }
 
@@ -185,8 +117,7 @@ function example() {
  */
 export function mountMockDemo(container: HTMLElement): () => void {
     const mockServer = new MockLSPServer();
-    const mockSocket = new MockWebSocket(mockServer);
-    const mockTransport = new MockTransport(mockSocket);
+    const mockTransport = new MockTransport(mockServer);
 
     const controls = document.createElement("div");
     controls.className = "demo-controls";

--- a/demo/shared/workerTransport.ts
+++ b/demo/shared/workerTransport.ts
@@ -1,55 +1,50 @@
-import { getNotifications } from "@open-rpc/client-js/build/Request";
-import type {
-    IJSONRPCData,
-    JSONRPCRequestData,
-} from "@open-rpc/client-js/build/Request";
-import { Transport } from "@open-rpc/client-js/build/transports/Transport";
 import type * as LSP from "vscode-languageserver-protocol";
-import { LanguageServerClient } from "../../src";
+import {
+    type JSONRPCMessage,
+    LanguageServerClient,
+    type Transport,
+} from "../../src";
 
 /**
- * An `@open-rpc/client-js` transport that speaks JSON-RPC to a Web Worker via
- * `postMessage`. It mirrors the built-in `PostMessageWindowTransport`: every
- * inbound message is fed to the request manager (which matches responses by id
- * and dispatches notifications), and outbound requests are posted verbatim.
- *
- * Notifications (`initialized`, `textDocument/didOpen`, `textDocument/didChange`)
- * have no id, so `settlePendingRequest` resolves their `sendData` promise
- * immediately — the client never waits on the worker for a fire-and-forget call.
+ * A {@link Transport} that speaks JSON-RPC to a Web Worker via `postMessage`.
+ * Structured clone carries the message objects verbatim, so — unlike a socket
+ * transport — there is no serialization step: outbound frames are posted as-is
+ * and inbound `MessageEvent` data is handed to the client directly.
  */
-export class WorkerTransport extends Transport {
-    private worker: Worker;
+export class WorkerTransport implements Transport {
+    private readonly worker: Worker;
+    private readonly handlers = new Set<(message: JSONRPCMessage) => void>();
 
-    private messageHandler = (event: MessageEvent) => {
-        this.transportRequestManager.resolveResponse(
-            JSON.stringify(event.data),
-        );
+    private readonly onWorkerMessage = (event: MessageEvent) => {
+        for (const handler of this.handlers) {
+            handler(event.data as JSONRPCMessage);
+        }
     };
 
     constructor(worker: Worker) {
-        super();
         this.worker = worker;
     }
 
     connect(): Promise<void> {
-        this.worker.addEventListener("message", this.messageHandler);
+        this.worker.addEventListener("message", this.onWorkerMessage);
         return Promise.resolve();
     }
 
-    close(): void {
-        this.worker.removeEventListener("message", this.messageHandler);
-        this.worker.terminate();
+    send(message: JSONRPCMessage): void {
+        this.worker.postMessage(message);
     }
 
-    async sendData(
-        data: JSONRPCRequestData,
-        timeout: number | null = null,
-    ): Promise<unknown> {
-        const promise = this.transportRequestManager.addRequest(data, timeout);
-        const notifications = getNotifications(data);
-        this.worker.postMessage((data as IJSONRPCData).request);
-        this.transportRequestManager.settlePendingRequest(notifications);
-        return promise;
+    onMessage(handler: (message: JSONRPCMessage) => void): () => void {
+        this.handlers.add(handler);
+        return () => {
+            this.handlers.delete(handler);
+        };
+    }
+
+    close(): void {
+        this.worker.removeEventListener("message", this.onWorkerMessage);
+        this.handlers.clear();
+        this.worker.terminate();
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -42,29 +42,29 @@
     "license": "BSD-3-Clause",
     "packageManager": "pnpm@10.33.4",
     "peerDependencies": {
+        "@codemirror/autocomplete": "^6",
+        "@codemirror/lint": "^6",
         "@codemirror/state": "^6",
         "@codemirror/view": "^6"
     },
     "devDependencies": {
+        "@astral-sh/ruff-wasm-web": "^0.15.20",
         "@biomejs/biome": "1.9.4",
+        "@codemirror/autocomplete": "^6.18.4",
         "@codemirror/lang-javascript": "^6.2.2",
+        "@codemirror/lang-python": "^6.2.1",
+        "@codemirror/lint": "^6.8.4",
         "@codemirror/state": "^6.5.2",
         "@codemirror/view": "^6.36.2",
+        "@typescript/vfs": "^1.6.4",
         "@vitest/coverage-v8": "3.2.4",
         "codemirror": "6.0.2",
-        "events": "3.3.0",
         "jsdom": "26.1.0",
         "typescript": "5.9.3",
         "vite": "6.4.2",
         "vitest": "3.2.4"
     },
     "dependencies": {
-        "@astral-sh/ruff-wasm-web": "^0.15.20",
-        "@codemirror/autocomplete": "^6.18.4",
-        "@codemirror/lang-python": "^6.2.1",
-        "@codemirror/lint": "^6.8.4",
-        "@open-rpc/client-js": "^1.8.1",
-        "@typescript/vfs": "^1.6.4",
         "marked": "^15.0.6",
         "vscode-languageserver-protocol": "^3.17.5"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,24 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@astral-sh/ruff-wasm-web':
-        specifier: ^0.15.20
-        version: 0.15.20
-      '@codemirror/autocomplete':
-        specifier: ^6.18.4
-        version: 6.20.1
-      '@codemirror/lang-python':
-        specifier: ^6.2.1
-        version: 6.2.1
-      '@codemirror/lint':
-        specifier: ^6.8.4
-        version: 6.9.5
-      '@open-rpc/client-js':
-        specifier: ^1.8.1
-        version: 1.8.1
-      '@typescript/vfs':
-        specifier: ^1.6.4
-        version: 1.6.4(typescript@5.9.3)
       marked:
         specifier: ^15.0.6
         version: 15.0.12
@@ -33,27 +15,39 @@ importers:
         specifier: ^3.17.5
         version: 3.17.5
     devDependencies:
+      '@astral-sh/ruff-wasm-web':
+        specifier: ^0.15.20
+        version: 0.15.20
       '@biomejs/biome':
         specifier: 1.9.4
         version: 1.9.4
+      '@codemirror/autocomplete':
+        specifier: ^6.18.4
+        version: 6.20.1
       '@codemirror/lang-javascript':
         specifier: ^6.2.2
         version: 6.2.5
+      '@codemirror/lang-python':
+        specifier: ^6.2.1
+        version: 6.2.1
+      '@codemirror/lint':
+        specifier: ^6.8.4
+        version: 6.9.5
       '@codemirror/state':
         specifier: ^6.5.2
         version: 6.6.0
       '@codemirror/view':
         specifier: ^6.36.2
         version: 6.41.1
+      '@typescript/vfs':
+        specifier: ^1.6.4
+        version: 1.6.4(typescript@5.9.3)
       '@vitest/coverage-v8':
         specifier: 3.2.4
         version: 3.2.4(vitest@3.2.4(jsdom@26.1.0))
       codemirror:
         specifier: 6.0.2
         version: 6.0.2
-      events:
-        specifier: 3.3.0
-        version: 3.3.0
       jsdom:
         specifier: 26.1.0
         version: 26.1.0
@@ -407,9 +401,6 @@ packages:
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
-  '@open-rpc/client-js@1.8.1':
-    resolution: {integrity: sha512-vV+Hetl688nY/oWI9IFY0iKDrWuLdYhf7OIKI6U1DcnJV7r4gAgwRJjEr1QVYszUc0gjkHoQJzqevmXMGLyA0g==}
-
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -722,10 +713,6 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
-  events@3.3.0:
-    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
-    engines: {node: '>=0.8.x'}
-
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -785,14 +772,6 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
-
-  isomorphic-fetch@3.0.0:
-    resolution: {integrity: sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==}
-
-  isomorphic-ws@5.0.0:
-    resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
-    peerDependencies:
-      ws: '*'
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -868,15 +847,6 @@ packages:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
-
-  node-fetch@2.7.0:
-    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
-    engines: {node: 4.x || >=6.0.0}
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
 
   nwsapi@2.2.23:
     resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
@@ -962,9 +932,6 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
-  strict-event-emitter-types@2.0.0:
-    resolution: {integrity: sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA==}
-
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -1030,9 +997,6 @@ packages:
   tough-cookie@5.1.2:
     resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
     engines: {node: '>=16'}
-
-  tr46@0.0.3:
-    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   tr46@5.1.1:
     resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
@@ -1133,9 +1097,6 @@ packages:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
 
-  webidl-conversions@3.0.1:
-    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
@@ -1145,9 +1106,6 @@ packages:
     engines: {node: '>=18'}
     deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
-  whatwg-fetch@3.6.20:
-    resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
-
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
     engines: {node: '>=18'}
@@ -1155,9 +1113,6 @@ packages:
   whatwg-url@14.2.0:
     resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
     engines: {node: '>=18'}
-
-  whatwg-url@5.0.0:
-    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -1176,18 +1131,6 @@ packages:
   wrap-ansi@8.1.0:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
-
-  ws@7.5.10:
-    resolution: {integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==}
-    engines: {node: '>=8.3.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: ^5.0.2
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
 
   ws@8.20.0:
     resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
@@ -1486,17 +1429,6 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.2': {}
 
-  '@open-rpc/client-js@1.8.1':
-    dependencies:
-      isomorphic-fetch: 3.0.0
-      isomorphic-ws: 5.0.0(ws@7.5.10)
-      strict-event-emitter-types: 2.0.0
-      ws: 7.5.10
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - utf-8-validate
-
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -1781,8 +1713,6 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
-  events@3.3.0: {}
-
   expect-type@1.3.0: {}
 
   fdir@6.5.0(picomatch@4.0.4):
@@ -1837,17 +1767,6 @@ snapshots:
   is-potential-custom-element-name@1.0.1: {}
 
   isexe@2.0.0: {}
-
-  isomorphic-fetch@3.0.0:
-    dependencies:
-      node-fetch: 2.7.0
-      whatwg-fetch: 3.6.20
-    transitivePeerDependencies:
-      - encoding
-
-  isomorphic-ws@5.0.0(ws@7.5.10):
-    dependencies:
-      ws: 7.5.10
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -1941,10 +1860,6 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  node-fetch@2.7.0:
-    dependencies:
-      whatwg-url: 5.0.0
-
   nwsapi@2.2.23: {}
 
   package-json-from-dist@1.0.1: {}
@@ -2033,8 +1948,6 @@ snapshots:
 
   std-env@3.10.0: {}
 
-  strict-event-emitter-types@2.0.0: {}
-
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
@@ -2097,8 +2010,6 @@ snapshots:
   tough-cookie@5.1.2:
     dependencies:
       tldts: 6.1.86
-
-  tr46@0.0.3: {}
 
   tr46@5.1.1:
     dependencies:
@@ -2194,15 +2105,11 @@ snapshots:
     dependencies:
       xml-name-validator: 5.0.0
 
-  webidl-conversions@3.0.1: {}
-
   webidl-conversions@7.0.0: {}
 
   whatwg-encoding@3.1.1:
     dependencies:
       iconv-lite: 0.6.3
-
-  whatwg-fetch@3.6.20: {}
 
   whatwg-mimetype@4.0.0: {}
 
@@ -2210,11 +2117,6 @@ snapshots:
     dependencies:
       tr46: 5.1.1
       webidl-conversions: 7.0.0
-
-  whatwg-url@5.0.0:
-    dependencies:
-      tr46: 0.0.3
-      webidl-conversions: 3.0.1
 
   which@2.0.2:
     dependencies:
@@ -2236,8 +2138,6 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 5.1.2
       strip-ansi: 7.2.0
-
-  ws@7.5.10: {}
 
   ws@8.20.0: {}
 

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,7 +1,14 @@
 import { EditorState, Text } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
-import { WebSocketTransport } from "@open-rpc/client-js";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+    afterAll,
+    beforeAll,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    vi,
+} from "vitest";
 import type {
     CompletionItem,
     Definition,
@@ -11,19 +18,29 @@ import type {
 } from "vscode-languageserver-protocol";
 import { LanguageServerClient } from "../lsp";
 import { languageServer, languageServerWithClient } from "../plugin";
+import { FakeTransport } from "../testing/fakeTransport";
 import { offsetToPos, posToOffset } from "../utils";
 
-// Mock WebSocket transport
-vi.mock("@open-rpc/client-js", () => ({
-    WebSocketTransport: vi.fn(),
-    Client: vi.fn(() => ({
-        request: vi.fn().mockResolvedValue({}),
-        notify: vi.fn(),
-        onNotification: vi.fn(),
-        close: vi.fn(),
-    })),
-    RequestManager: vi.fn(),
-}));
+// The `languageServer({ serverUri })` integration test drives the real
+// WebSocketTransport. Stub the global WebSocket so it never opens a real
+// connection (jsdom otherwise dials `ws://test` and rejects on the ".test"
+// public suffix).
+class StubWebSocket {
+    static readonly OPEN = 1;
+    readyState = 0;
+    addEventListener(): void {}
+    removeEventListener(): void {}
+    send(): void {}
+    close(): void {}
+}
+
+beforeAll(() => {
+    vi.stubGlobal("WebSocket", StubWebSocket);
+});
+
+afterAll(() => {
+    vi.unstubAllGlobals();
+});
 
 const createMockClient = (
     init?: Partial<LanguageServerClient>,
@@ -91,14 +108,21 @@ describe("LanguageServer", () => {
 
     describe("LanguageServerClient", () => {
         let client: LanguageServerClient;
-        const mockTransport = new WebSocketTransport("ws://test");
 
         beforeEach(() => {
             client = new LanguageServerClient({
-                transport: mockTransport,
+                transport: new FakeTransport(),
                 rootUri: "file:///test",
                 workspaceFolders: [{ uri: "file:///test", name: "test" }],
             });
+            // Drive the internal JSON-RPC client directly; the transport
+            // handshake is exercised separately.
+            // biome-ignore lint/suspicious/noExplicitAny: test override
+            (client as any).client.request = vi.fn().mockResolvedValue({});
+            // biome-ignore lint/suspicious/noExplicitAny: test override
+            (client as any).client.notify = vi
+                .fn()
+                .mockResolvedValue(undefined);
         });
 
         it("should initialize with correct capabilities", async () => {
@@ -147,10 +171,8 @@ describe("LanguageServer", () => {
 
             // biome-ignore lint/suspicious/noExplicitAny: <explanation>
             expect((client as any).client.request).toHaveBeenCalledWith(
-                {
-                    method: "completionItem/resolve",
-                    params: mockCompletionItem,
-                },
+                "completionItem/resolve",
+                mockCompletionItem,
                 10000,
             );
             expect(result).toEqual(resolvedItem);
@@ -170,10 +192,10 @@ describe("LanguageServer", () => {
             await client.textDocumentDidChange(params);
 
             // biome-ignore lint/suspicious/noExplicitAny: <explanation>
-            expect((client as any).client.notify).toHaveBeenCalledWith({
-                method: "textDocument/didChange",
+            expect((client as any).client.notify).toHaveBeenCalledWith(
+                "textDocument/didChange",
                 params,
-            });
+            );
         });
     });
 
@@ -475,8 +497,12 @@ describe("exports", () => {
         const exports = await import("../index");
         expect(Object.keys(exports).sort()).toMatchInlineSnapshot(`
           [
+            "ErrorCodes",
+            "JSONRPCClient",
             "LanguageServerClient",
             "LanguageServerPlugin",
+            "RPCError",
+            "WebSocketTransport",
             "documentUri",
             "getLanguageServerPlugin",
             "languageId",

--- a/src/__tests__/jsonrpc.test.ts
+++ b/src/__tests__/jsonrpc.test.ts
@@ -230,6 +230,18 @@ describe("notify and respond", () => {
         ).resolves.toBeUndefined();
         expect(transport.sent).toEqual([]);
     });
+
+    it("does not send a notification queued before connect once closed mid-connect", async () => {
+        const transport = new ControlledTransport(false);
+        const client = new JSONRPCClient(transport);
+
+        const notified = client.notify("x", {});
+        client.close(); // tear down before the connection resolves
+        transport.openConnection();
+        await notified;
+
+        expect(transport.sent).toEqual([]);
+    });
 });
 
 describe("inbound routing", () => {

--- a/src/__tests__/jsonrpc.test.ts
+++ b/src/__tests__/jsonrpc.test.ts
@@ -11,6 +11,7 @@ import {
 class ControlledTransport implements Transport {
     readonly sent: JSONRPCMessage[] = [];
     closed = false;
+    throwOnSend = false;
     private handler?: (message: JSONRPCMessage) => void;
     private resolveConnect!: () => void;
     private rejectConnect!: (reason: unknown) => void;
@@ -29,6 +30,9 @@ class ControlledTransport implements Transport {
     }
 
     send(message: JSONRPCMessage): void {
+        if (this.throwOnSend) {
+            throw new Error("send failed");
+        }
         this.sent.push(message);
     }
 
@@ -164,6 +168,28 @@ describe("request", () => {
         await expect(pending).rejects.toThrow("no route");
         expect(transport.sent).toEqual([]);
     });
+
+    it("settles immediately when the transport send throws", async () => {
+        const transport = new ControlledTransport();
+        transport.throwOnSend = true;
+        const client = new JSONRPCClient(transport);
+
+        await expect(client.request("m", {}, 1000)).rejects.toThrow(
+            "send failed",
+        );
+    });
+
+    it("rejects requests started after close without waiting for a timeout", async () => {
+        const transport = new ControlledTransport();
+        const client = new JSONRPCClient(transport);
+        client.close();
+
+        await expect(client.request("m", {}, 1000)).rejects.toMatchObject({
+            name: "RPCError",
+            message: "Client closed",
+        });
+        expect(transport.sent).toEqual([]);
+    });
 });
 
 describe("notify and respond", () => {
@@ -191,6 +217,18 @@ describe("notify and respond", () => {
         expect(transport.sent).toEqual([
             { jsonrpc: "2.0", id: 5, result: null },
         ]);
+    });
+
+    it("drops notifications and responses after close without rejecting", async () => {
+        const transport = new ControlledTransport();
+        const client = new JSONRPCClient(transport);
+        client.close();
+
+        await expect(client.notify("x", {})).resolves.toBeUndefined();
+        await expect(
+            client.respond({ jsonrpc: "2.0", id: 1, result: null }),
+        ).resolves.toBeUndefined();
+        expect(transport.sent).toEqual([]);
     });
 });
 

--- a/src/__tests__/jsonrpc.test.ts
+++ b/src/__tests__/jsonrpc.test.ts
@@ -1,0 +1,275 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+    ErrorCodes,
+    JSONRPCClient,
+    type JSONRPCMessage,
+    RPCError,
+    type Transport,
+} from "../jsonrpc.js";
+
+/** A transport whose connection and inbound frames the test drives by hand. */
+class ControlledTransport implements Transport {
+    readonly sent: JSONRPCMessage[] = [];
+    closed = false;
+    private handler?: (message: JSONRPCMessage) => void;
+    private resolveConnect!: () => void;
+    private rejectConnect!: (reason: unknown) => void;
+    private readonly connectPromise = new Promise<void>((resolve, reject) => {
+        this.resolveConnect = resolve;
+        this.rejectConnect = reject;
+    });
+
+    constructor(private readonly autoConnect = true) {}
+
+    connect(): Promise<void> {
+        if (this.autoConnect) {
+            this.resolveConnect();
+        }
+        return this.connectPromise;
+    }
+
+    send(message: JSONRPCMessage): void {
+        this.sent.push(message);
+    }
+
+    onMessage(handler: (message: JSONRPCMessage) => void): () => void {
+        this.handler = handler;
+        return () => {
+            this.handler = undefined;
+        };
+    }
+
+    close(): void {
+        this.closed = true;
+    }
+
+    receive(message: JSONRPCMessage): void {
+        this.handler?.(message);
+    }
+
+    openConnection(): void {
+        this.resolveConnect();
+    }
+
+    failConnection(reason: unknown): void {
+        this.rejectConnect(reason);
+    }
+
+    get hasHandler(): boolean {
+        return this.handler !== undefined;
+    }
+}
+
+/** Flush pending microtasks (the connect→send hop). */
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+afterEach(() => {
+    vi.useRealTimers();
+});
+
+describe("request", () => {
+    it("sends a well-formed frame with incrementing ids and resolves on match", async () => {
+        const transport = new ControlledTransport();
+        const client = new JSONRPCClient(transport);
+
+        const first = client.request("a/b", { x: 1 }, 1000);
+        const second = client.request("c/d", { y: 2 }, 1000);
+        await tick();
+
+        expect(transport.sent).toEqual([
+            { jsonrpc: "2.0", id: 0, method: "a/b", params: { x: 1 } },
+            { jsonrpc: "2.0", id: 1, method: "c/d", params: { y: 2 } },
+        ]);
+
+        // Answer out of order to prove correlation is by id, not arrival.
+        transport.receive({ jsonrpc: "2.0", id: 1, result: "second" });
+        transport.receive({ jsonrpc: "2.0", id: 0, result: "first" });
+
+        await expect(first).resolves.toBe("first");
+        await expect(second).resolves.toBe("second");
+    });
+
+    it("rejects with an RPCError carrying the server code, message, and data", async () => {
+        const transport = new ControlledTransport();
+        const client = new JSONRPCClient(transport);
+
+        const pending = client.request("boom", {}, 1000);
+        await tick();
+        transport.receive({
+            jsonrpc: "2.0",
+            id: 0,
+            error: { code: -32001, message: "nope", data: { detail: 1 } },
+        });
+
+        await expect(pending).rejects.toMatchObject({
+            name: "RPCError",
+            code: -32001,
+            message: "nope",
+            data: { detail: 1 },
+        });
+    });
+
+    it("rejects with a timeout error when no response arrives", async () => {
+        vi.useFakeTimers();
+        const transport = new ControlledTransport();
+        const client = new JSONRPCClient(transport);
+
+        const pending = client.request("slow", {}, 1000);
+        pending.catch(() => {}); // avoid unhandled rejection while advancing
+        await vi.advanceTimersByTimeAsync(1000);
+
+        await expect(pending).rejects.toMatchObject({
+            name: "RPCError",
+            code: ErrorCodes.RequestTimeout,
+        });
+    });
+
+    it("ignores a response with an unknown id", async () => {
+        const transport = new ControlledTransport();
+        const client = new JSONRPCClient(transport);
+
+        const pending = client.request("m", {}, 1000);
+        await tick();
+        transport.receive({ jsonrpc: "2.0", id: 999, result: "stray" });
+        transport.receive({ jsonrpc: "2.0", id: 0, result: "real" });
+
+        await expect(pending).resolves.toBe("real");
+    });
+
+    it("waits for the connection before sending, then flushes", async () => {
+        const transport = new ControlledTransport(false);
+        const client = new JSONRPCClient(transport);
+
+        const pending = client.request("m", { a: 1 }, 1000);
+        await tick();
+        expect(transport.sent).toEqual([]); // still connecting
+
+        transport.openConnection();
+        await tick();
+        expect(transport.sent).toEqual([
+            { jsonrpc: "2.0", id: 0, method: "m", params: { a: 1 } },
+        ]);
+
+        transport.receive({ jsonrpc: "2.0", id: 0, result: "ok" });
+        await expect(pending).resolves.toBe("ok");
+    });
+
+    it("rejects in-flight requests when the connection fails", async () => {
+        const transport = new ControlledTransport(false);
+        const client = new JSONRPCClient(transport);
+
+        const pending = client.request("m", {}, 1000);
+        transport.failConnection(new Error("no route"));
+
+        await expect(pending).rejects.toThrow("no route");
+        expect(transport.sent).toEqual([]);
+    });
+});
+
+describe("notify and respond", () => {
+    it("sends a notification frame with no id", async () => {
+        const transport = new ControlledTransport();
+        const client = new JSONRPCClient(transport);
+
+        await client.notify("textDocument/didOpen", { uri: "file:///x" });
+
+        expect(transport.sent).toEqual([
+            {
+                jsonrpc: "2.0",
+                method: "textDocument/didOpen",
+                params: { uri: "file:///x" },
+            },
+        ]);
+    });
+
+    it("sends a response frame verbatim", async () => {
+        const transport = new ControlledTransport();
+        const client = new JSONRPCClient(transport);
+
+        await client.respond({ jsonrpc: "2.0", id: 5, result: null });
+
+        expect(transport.sent).toEqual([
+            { jsonrpc: "2.0", id: 5, result: null },
+        ]);
+    });
+});
+
+describe("inbound routing", () => {
+    it("routes notifications to the notification handler", async () => {
+        const transport = new ControlledTransport();
+        const client = new JSONRPCClient(transport);
+        const onNotification = vi.fn();
+        client.onNotification(onNotification);
+
+        const frame = {
+            jsonrpc: "2.0" as const,
+            method: "window/logMessage",
+            params: { message: "hi" },
+        };
+        transport.receive(frame);
+
+        expect(onNotification).toHaveBeenCalledWith(frame);
+    });
+
+    it("routes server-initiated requests (with an id) to the request handler", () => {
+        const transport = new ControlledTransport();
+        const client = new JSONRPCClient(transport);
+        const onRequest = vi.fn();
+        client.onRequest(onRequest);
+
+        const frame = {
+            jsonrpc: "2.0" as const,
+            id: 0,
+            method: "workspace/configuration",
+            params: { items: [] },
+        };
+        transport.receive(frame);
+
+        expect(onRequest).toHaveBeenCalledWith(frame);
+    });
+
+    it("ignores non-object frames without throwing", () => {
+        const transport = new ControlledTransport();
+        const client = new JSONRPCClient(transport);
+        const onNotification = vi.fn();
+        client.onNotification(onNotification);
+
+        expect(() =>
+            transport.receive(null as unknown as JSONRPCMessage),
+        ).not.toThrow();
+        expect(onNotification).not.toHaveBeenCalled();
+    });
+});
+
+describe("close", () => {
+    it("rejects pending requests, unsubscribes, and closes the transport", async () => {
+        const transport = new ControlledTransport();
+        const client = new JSONRPCClient(transport);
+
+        const pending = client.request("m", {}, 1000);
+        await tick();
+        client.close();
+
+        await expect(pending).rejects.toBeInstanceOf(RPCError);
+        expect(transport.closed).toBe(true);
+        expect(transport.hasHandler).toBe(false);
+    });
+
+    it("is idempotent and drops inbound frames after close", async () => {
+        const transport = new ControlledTransport();
+        const client = new JSONRPCClient(transport);
+        const onNotification = vi.fn();
+        client.onNotification(onNotification);
+
+        client.close();
+        expect(() => client.close()).not.toThrow();
+
+        // The handler was removed on close; even a direct receive is inert.
+        transport.receive({
+            jsonrpc: "2.0",
+            method: "window/logMessage",
+            params: {},
+        });
+        expect(onNotification).not.toHaveBeenCalled();
+    });
+});

--- a/src/__tests__/language-server-client.test.ts
+++ b/src/__tests__/language-server-client.test.ts
@@ -1,59 +1,19 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { LanguageServerPlugin } from "../plugin.js";
 
-import type Client from "@open-rpc/client-js";
-import { Transport } from "@open-rpc/client-js/build/transports/Transport.js";
 import type * as LSP from "vscode-languageserver-protocol";
+import type { JSONRPCClient } from "../jsonrpc.js";
 import {
     LanguageServerClient,
     type LanguageServerClientOptions,
 } from "../lsp.js";
-
-// Create a simple mock transport
-class MockTransport extends Transport {
-    sendData = vi.fn().mockResolvedValue({});
-    subscribe = vi.fn();
-    unsubscribe = vi.fn();
-    connect = vi.fn().mockResolvedValue({});
-    close = vi.fn();
-
-    emit = vi.fn();
-    addListener = vi.fn();
-    on = vi.fn();
-    once = vi.fn();
-    removeListener = vi.fn();
-    off = vi.fn();
-    removeAllListeners = vi.fn();
-    setMaxListeners = vi.fn();
-    getMaxListeners = vi.fn();
-    listeners = vi.fn();
-    rawListeners = vi.fn();
-    listenerCount = vi.fn();
-    prependListener = vi.fn();
-    prependOnceListener = vi.fn();
-    eventNames = vi.fn();
-    parseData = vi.fn();
-}
-
-// Mock the Client from @open-rpc/client-js
-vi.mock("@open-rpc/client-js", () => ({
-    Client: vi.fn().mockImplementation(() => ({
-        request: vi.fn().mockResolvedValue({}),
-        notify: vi.fn().mockResolvedValue(undefined),
-        close: vi.fn(),
-        onNotification: vi.fn(),
-        onRequest: vi.fn(),
-    })),
-    RequestManager: vi.fn().mockImplementation(() => ({
-        requestTimeoutMs: 10000,
-    })),
-}));
+import { FakeTransport } from "../testing/fakeTransport.js";
 
 describe("LanguageServerClient", () => {
-    let mockTransport: MockTransport;
+    let mockTransport: FakeTransport;
 
     beforeEach(() => {
-        mockTransport = new MockTransport();
+        mockTransport = new FakeTransport();
     });
 
     describe("constructor", () => {
@@ -278,7 +238,7 @@ describe("LanguageServerClient", () => {
             const mockInternalClient = {
                 close: vi.fn(),
                 notify: vi.fn(),
-            } as unknown as Client;
+            } as unknown as JSONRPCClient;
             // @ts-expect-error: Accessing private method for test purposes
             client.client = mockInternalClient;
 

--- a/src/__tests__/language-server-plugin.test.ts
+++ b/src/__tests__/language-server-plugin.test.ts
@@ -1,11 +1,11 @@
 import { EditorState } from "@codemirror/state";
 import { EditorView, type ViewUpdate } from "@codemirror/view";
-import { Transport } from "@open-rpc/client-js/build/transports/Transport.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type * as LSP from "vscode-languageserver-protocol";
 import { CompletionTriggerKind } from "vscode-languageserver-protocol";
 import { type FeatureOptions, LanguageServerClient } from "../lsp.js";
 import { LanguageServerPlugin } from "../plugin.js";
+import { FakeTransport } from "../testing/fakeTransport.js";
 
 // Note: jsdom environment provides document
 
@@ -50,53 +50,14 @@ vi.mock("../utils.js", () => ({
     showErrorMessage: vi.fn(),
 }));
 
-// Mock the Client from @open-rpc/client-js
-vi.mock("@open-rpc/client-js", () => ({
-    Client: vi.fn().mockImplementation(() => ({
-        request: vi.fn().mockResolvedValue({}),
-        notify: vi.fn().mockResolvedValue(undefined),
-        close: vi.fn(),
-        onNotification: vi.fn(),
-        onRequest: vi.fn(),
-    })),
-    RequestManager: vi.fn().mockImplementation(() => ({
-        requestTimeoutMs: 10000,
-    })),
-}));
-
-// Create a simple mock transport
-class MockTransport extends Transport {
-    sendData = vi.fn().mockResolvedValue({});
-    subscribe = vi.fn();
-    unsubscribe = vi.fn();
-    connect = vi.fn().mockResolvedValue({});
-    close = vi.fn();
-
-    emit = vi.fn();
-    addListener = vi.fn();
-    on = vi.fn();
-    once = vi.fn();
-    removeListener = vi.fn();
-    off = vi.fn();
-    removeAllListeners = vi.fn();
-    setMaxListeners = vi.fn();
-    getMaxListeners = vi.fn();
-    listeners = vi.fn();
-    rawListeners = vi.fn();
-    listenerCount = vi.fn();
-    prependListener = vi.fn();
-    prependOnceListener = vi.fn();
-    eventNames = vi.fn();
-}
-
 describe("LanguageServerPlugin", () => {
     let mockClient: LanguageServerClient;
-    let mockTransport: MockTransport;
+    let mockTransport: FakeTransport;
     let mockView: EditorView;
     let featureOptions: Required<FeatureOptions>;
 
     beforeEach(() => {
-        mockTransport = new MockTransport();
+        mockTransport = new FakeTransport();
 
         // Create a mock client
         mockClient = new LanguageServerClient({

--- a/src/__tests__/languageServer.test.ts
+++ b/src/__tests__/languageServer.test.ts
@@ -1,6 +1,5 @@
 import { EditorState } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
-import { Transport } from "@open-rpc/client-js/build/transports/Transport";
 import { describe, expect, it, vi } from "vitest";
 import type {
     ClientCapabilities,
@@ -8,16 +7,9 @@ import type {
 } from "vscode-languageserver-protocol";
 import { type FeatureOptions, LanguageServerClient } from "../lsp";
 import { LanguageServerPlugin } from "../plugin";
+import { FakeTransport } from "../testing/fakeTransport";
 
-class MockTransport extends Transport {
-    sendData = vi.fn().mockResolvedValue({});
-    subscribe = vi.fn();
-    unsubscribe = vi.fn();
-    connect = vi.fn().mockResolvedValue({});
-    close = vi.fn();
-}
-
-const transport = new MockTransport();
+const transport = new FakeTransport();
 
 class MockLanguageServerPlugin extends LanguageServerPlugin {
     public applyRenameEdit(
@@ -138,8 +130,8 @@ it("handles rename preparation and execution", async () => {
 
     // Mock the client's methods for rename
     // biome-ignore lint/suspicious/noExplicitAny: tests
-    (client as any).client.request = vi.fn().mockImplementation((request) => {
-        if (request.method === "textDocument/prepareRename") {
+    (client as any).client.request = vi.fn().mockImplementation((method) => {
+        if (method === "textDocument/prepareRename") {
             return Promise.resolve({
                 range: {
                     start: { line: 1, character: 5 },
@@ -147,7 +139,7 @@ it("handles rename preparation and execution", async () => {
                 },
             });
         }
-        if (request.method === "textDocument/rename") {
+        if (method === "textDocument/rename") {
             return Promise.resolve({
                 changes: {
                     "file:///root/file.ts": [
@@ -222,25 +214,21 @@ it("handles rename preparation and execution", async () => {
     // Verify the correct methods were called
     // biome-ignore lint/suspicious/noExplicitAny: tests
     expect((client as any).client.request).toHaveBeenCalledWith(
+        "textDocument/prepareRename",
         {
-            method: "textDocument/prepareRename",
-            params: {
-                textDocument: { uri: "file:///root/file.ts" },
-                position: { line: 1, character: 5 },
-            },
+            textDocument: { uri: "file:///root/file.ts" },
+            position: { line: 1, character: 5 },
         },
         10000,
     );
 
     // biome-ignore lint/suspicious/noExplicitAny: tests
     expect((client as any).client.request).toHaveBeenCalledWith(
+        "textDocument/rename",
         {
-            method: "textDocument/rename",
-            params: {
-                textDocument: { uri: "file:///root/file.ts" },
-                position: { line: 1, character: 5 },
-                newName: "newName",
-            },
+            textDocument: { uri: "file:///root/file.ts" },
+            position: { line: 1, character: 5 },
+            newName: "newName",
         },
         10000,
     );
@@ -264,8 +252,8 @@ it("applies rename changes correctly to a document", async () => {
     (client as any).client.request = vi
         .fn()
         // biome-ignore lint/suspicious/noExplicitAny: <explanation>
-        .mockImplementation((request: any) => {
-            if (request.method === "textDocument/rename") {
+        .mockImplementation((method: any) => {
+            if (method === "textDocument/rename") {
                 return Promise.resolve<WorkspaceEdit>({
                     documentChanges: [
                         {
@@ -343,8 +331,8 @@ it("applies rename the whole cell", async () => {
 
     // Mock the client's methods for rename
     // biome-ignore lint/suspicious/noExplicitAny: tests
-    (client as any).client.request = vi.fn().mockImplementation((request) => {
-        if (request.method === "textDocument/rename") {
+    (client as any).client.request = vi.fn().mockImplementation((method) => {
+        if (method === "textDocument/rename") {
             return Promise.resolve<WorkspaceEdit>({
                 documentChanges: [
                     {

--- a/src/__tests__/lsp-robustness.test.ts
+++ b/src/__tests__/lsp-robustness.test.ts
@@ -1,66 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { LanguageServerClient } from "../lsp.js";
+import { FakeTransport } from "../testing/fakeTransport.js";
 
-// biome-ignore lint/suspicious/noExplicitAny: test helpers
-const clientInstances: any[] = [];
-let failInitialize = false;
-
-vi.mock("@open-rpc/client-js", () => ({
-    Client: vi.fn().mockImplementation(() => {
-        const instance = {
-            request: vi
-                .fn()
-                .mockImplementation(() =>
-                    failInitialize
-                        ? Promise.reject(new Error("server down"))
-                        : Promise.resolve({ capabilities: {} }),
-                ),
-            notify: vi.fn().mockResolvedValue(undefined),
-            close: vi.fn(),
-            onNotification: vi.fn(),
-        };
-        clientInstances.push(instance);
-        return instance;
-    }),
-    RequestManager: vi.fn(),
-}));
-
-function createFakeTransport() {
-    // Stands in for the TransportRequestManager every @open-rpc/client-js
-    // transport routes incoming frames through; the client patches
-    // resolveResponse to intercept server->client requests.
-    const originalResolveResponse = vi.fn();
-    return {
-        transportRequestManager: {
-            resolveResponse: originalResolveResponse,
-        },
-        originalResolveResponse,
-        sendData: vi.fn().mockResolvedValue({}),
-        subscribe: vi.fn(),
-        unsubscribe: vi.fn(),
-        connect: vi.fn().mockResolvedValue({}),
-        close: vi.fn(),
-        // biome-ignore lint/suspicious/noExplicitAny: minimal transport stub
-    } as any;
-}
-
-/** Simulates an incoming frame arriving on the transport */
-// biome-ignore lint/suspicious/noExplicitAny: test helper
-function receiveFrame(transport: any, frame: unknown) {
-    transport.transportRequestManager.resolveResponse(
-        typeof frame === "string" ? frame : JSON.stringify(frame),
-    );
-}
-
-// biome-ignore lint/suspicious/noExplicitAny: inspecting mock args
-function sentResponses(transport: any) {
-    return transport.sendData.mock.calls.map(
-        // biome-ignore lint/suspicious/noExplicitAny: inspecting mock args
-        (call: any[]) => call[0].request,
-    );
-}
-
-function baseOptions(transport = createFakeTransport()) {
+function baseOptions(transport: FakeTransport) {
     return {
         rootUri: "file:///test",
         workspaceFolders: null,
@@ -75,8 +17,7 @@ async function flushTicks(count = 5) {
 }
 
 beforeEach(() => {
-    clientInstances.length = 0;
-    failInitialize = false;
+    vi.restoreAllMocks();
 });
 
 describe("initialize failure handling", () => {
@@ -86,8 +27,10 @@ describe("initialize failure handling", () => {
         process.on("unhandledRejection", onUnhandled);
 
         try {
-            failInitialize = true;
-            const client = new LanguageServerClient(baseOptions());
+            const transport = new FakeTransport({
+                failInitialize: { code: -32000, message: "server down" },
+            });
+            const client = new LanguageServerClient(baseOptions(transport));
 
             await flushTicks();
             expect(unhandled).toEqual([]);
@@ -102,7 +45,9 @@ describe("initialize failure handling", () => {
     });
 
     it("becomes ready when initialize succeeds", async () => {
-        const client = new LanguageServerClient(baseOptions());
+        const client = new LanguageServerClient(
+            baseOptions(new FakeTransport()),
+        );
         await flushTicks();
         expect(client.ready).toBe(true);
     });
@@ -110,10 +55,10 @@ describe("initialize failure handling", () => {
 
 describe("server request handling", () => {
     it("answers unhandled requests with MethodNotFound and a matching id (including id 0)", async () => {
-        const transport = createFakeTransport();
+        const transport = new FakeTransport();
         new LanguageServerClient(baseOptions(transport));
 
-        receiveFrame(transport, {
+        transport.receive({
             jsonrpc: "2.0",
             id: 0,
             method: "workspace/unknownMethod",
@@ -121,7 +66,7 @@ describe("server request handling", () => {
         });
         await flushTicks();
 
-        expect(sentResponses(transport)).toEqual([
+        expect(transport.serverResponses()).toEqual([
             {
                 jsonrpc: "2.0",
                 id: 0,
@@ -131,27 +76,25 @@ describe("server request handling", () => {
                 },
             },
         ]);
-        // The request must not leak into the response/notification path
-        expect(transport.originalResolveResponse).not.toHaveBeenCalled();
     });
 
     it("answers workspace/applyEdit and window requests with spec-valid no-op results", async () => {
-        const transport = createFakeTransport();
+        const transport = new FakeTransport();
         new LanguageServerClient(baseOptions(transport));
 
-        receiveFrame(transport, {
+        transport.receive({
             jsonrpc: "2.0",
             id: 1,
             method: "workspace/applyEdit",
             params: { edit: { changes: {} } },
         });
-        receiveFrame(transport, {
+        transport.receive({
             jsonrpc: "2.0",
             id: 2,
             method: "window/showMessageRequest",
             params: { type: 1, message: "pick one", actions: [] },
         });
-        receiveFrame(transport, {
+        transport.receive({
             jsonrpc: "2.0",
             id: 3,
             method: "window/workDoneProgress/create",
@@ -159,7 +102,7 @@ describe("server request handling", () => {
         });
         await flushTicks();
 
-        expect(sentResponses(transport)).toEqual([
+        expect(transport.serverResponses()).toEqual([
             {
                 jsonrpc: "2.0",
                 id: 1,
@@ -174,14 +117,14 @@ describe("server request handling", () => {
     });
 
     it("answers workspace/configuration requests via getWorkspaceConfiguration", async () => {
-        const transport = createFakeTransport();
+        const transport = new FakeTransport();
         const getWorkspaceConfiguration = vi.fn().mockReturnValue([{ a: 1 }]);
         new LanguageServerClient({
             ...baseOptions(transport),
             getWorkspaceConfiguration,
         });
 
-        receiveFrame(transport, {
+        transport.receive({
             jsonrpc: "2.0",
             id: 0,
             method: "workspace/configuration",
@@ -190,16 +133,16 @@ describe("server request handling", () => {
         await flushTicks();
 
         expect(getWorkspaceConfiguration).toHaveBeenCalledWith({ items: [] });
-        expect(sentResponses(transport)).toEqual([
+        expect(transport.serverResponses()).toEqual([
             { jsonrpc: "2.0", id: 0, result: [{ a: 1 }] },
         ]);
     });
 
     it("answers workspace/configuration with one null per item when no option is provided", async () => {
-        const transport = createFakeTransport();
+        const transport = new FakeTransport();
         new LanguageServerClient(baseOptions(transport));
 
-        receiveFrame(transport, {
+        transport.receive({
             jsonrpc: "2.0",
             id: 7,
             method: "workspace/configuration",
@@ -207,18 +150,18 @@ describe("server request handling", () => {
         });
         await flushTicks();
 
-        expect(sentResponses(transport)).toEqual([
+        expect(transport.serverResponses()).toEqual([
             { jsonrpc: "2.0", id: 7, result: [null, null] },
         ]);
     });
 
     it("dispatches to onRequest handlers and unsubscribes them", async () => {
-        const transport = createFakeTransport();
+        const transport = new FakeTransport();
         const client = new LanguageServerClient(baseOptions(transport));
         const handler = vi.fn().mockResolvedValue({ ok: true });
         const dispose = client.onRequest("custom/method", handler);
 
-        receiveFrame(transport, {
+        transport.receive({
             jsonrpc: "2.0",
             id: 1,
             method: "custom/method",
@@ -227,12 +170,12 @@ describe("server request handling", () => {
         await flushTicks();
 
         expect(handler).toHaveBeenCalledWith({ x: 1 });
-        expect(sentResponses(transport)).toEqual([
+        expect(transport.serverResponses()).toEqual([
             { jsonrpc: "2.0", id: 1, result: { ok: true } },
         ]);
 
         dispose();
-        receiveFrame(transport, {
+        transport.receive({
             jsonrpc: "2.0",
             id: 2,
             method: "custom/method",
@@ -241,7 +184,7 @@ describe("server request handling", () => {
         await flushTicks();
 
         expect(handler).toHaveBeenCalledTimes(1);
-        expect(sentResponses(transport)[1]).toEqual({
+        expect(transport.serverResponses()[1]).toEqual({
             jsonrpc: "2.0",
             id: 2,
             error: {
@@ -252,20 +195,20 @@ describe("server request handling", () => {
     });
 
     it("replies with an internal error when a handler throws, and stays usable", async () => {
-        const transport = createFakeTransport();
+        const transport = new FakeTransport();
         const client = new LanguageServerClient(baseOptions(transport));
         client.onRequest("custom/fails", () => {
             throw new Error("boom");
         });
         client.onRequest("custom/works", () => "fine");
 
-        receiveFrame(transport, {
+        transport.receive({
             jsonrpc: "2.0",
             id: 1,
             method: "custom/fails",
             params: {},
         });
-        receiveFrame(transport, {
+        transport.receive({
             jsonrpc: "2.0",
             id: 2,
             method: "custom/works",
@@ -273,7 +216,7 @@ describe("server request handling", () => {
         });
         await flushTicks();
 
-        expect(sentResponses(transport)).toEqual([
+        expect(transport.serverResponses()).toEqual([
             {
                 jsonrpc: "2.0",
                 id: 1,
@@ -284,11 +227,11 @@ describe("server request handling", () => {
     });
 
     it("coerces a handler's undefined result to null", async () => {
-        const transport = createFakeTransport();
+        const transport = new FakeTransport();
         const client = new LanguageServerClient(baseOptions(transport));
         client.onRequest("custom/void", () => undefined);
 
-        receiveFrame(transport, {
+        transport.receive({
             jsonrpc: "2.0",
             id: 3,
             method: "custom/void",
@@ -296,44 +239,43 @@ describe("server request handling", () => {
         });
         await flushTicks();
 
-        expect(sentResponses(transport)).toEqual([
+        expect(transport.serverResponses()).toEqual([
             { jsonrpc: "2.0", id: 3, result: null },
         ]);
     });
 
-    it("forwards non-JSON frames, notifications, and responses untouched", async () => {
-        const transport = createFakeTransport();
-        new LanguageServerClient(baseOptions(transport));
+    it("routes notifications to listeners and ignores responses without answering", async () => {
+        const transport = new FakeTransport();
+        const client = new LanguageServerClient(baseOptions(transport));
+        const listener = vi.fn();
+        client.onNotification(listener);
 
-        const notification = JSON.stringify({
+        const notification = {
+            jsonrpc: "2.0" as const,
+            method: "textDocument/publishDiagnostics" as const,
+            params: { uri: "file:///x", diagnostics: [] },
+        };
+        // A notification (no id) reaches listeners; a response for an unknown
+        // id is silently ignored. Neither elicits a reply to the server.
+        transport.receive(notification);
+        transport.receive({
             jsonrpc: "2.0",
-            method: "window/logMessage",
-            params: {},
-        });
-        const response = JSON.stringify({
-            jsonrpc: "2.0",
-            id: 1,
+            id: 999,
             result: { capabilities: {} },
         });
-
-        receiveFrame(transport, "ping");
-        receiveFrame(transport, notification);
-        receiveFrame(transport, response);
         await flushTicks();
 
-        expect(transport.sendData).not.toHaveBeenCalled();
-        expect(
-            transport.originalResolveResponse.mock.calls.map((c) => c[0]),
-        ).toEqual(["ping", notification, response]);
+        expect(listener).toHaveBeenCalledWith(notification);
+        expect(transport.serverResponses()).toEqual([]);
     });
 
     it("tracks dynamic capability (un)registration via hasCapability", async () => {
-        const transport = createFakeTransport();
+        const transport = new FakeTransport();
         const client = new LanguageServerClient(baseOptions(transport));
 
         expect(client.hasCapability("textDocument/formatting")).toBe(false);
 
-        receiveFrame(transport, {
+        transport.receive({
             jsonrpc: "2.0",
             id: 1,
             method: "client/registerCapability",
@@ -350,11 +292,11 @@ describe("server request handling", () => {
         await flushTicks();
 
         expect(client.hasCapability("textDocument/formatting")).toBe(true);
-        expect(sentResponses(transport)).toEqual([
+        expect(transport.serverResponses()).toEqual([
             { jsonrpc: "2.0", id: 1, result: null },
         ]);
 
-        receiveFrame(transport, {
+        transport.receive({
             jsonrpc: "2.0",
             id: 2,
             method: "client/unregisterCapability",
@@ -367,7 +309,7 @@ describe("server request handling", () => {
         await flushTicks();
 
         expect(client.hasCapability("textDocument/formatting")).toBe(false);
-        expect(sentResponses(transport)[1]).toEqual({
+        expect(transport.serverResponses()[1]).toEqual({
             jsonrpc: "2.0",
             id: 2,
             result: null,
@@ -376,13 +318,10 @@ describe("server request handling", () => {
 });
 
 describe("close()", () => {
-    it("marks the client not ready, clears listeners, and detaches the request interceptor", async () => {
-        const transport = createFakeTransport();
+    it("marks the client not ready, clears listeners, and closes the transport", async () => {
+        const transport = new FakeTransport();
+        const closeSpy = vi.spyOn(transport, "close");
         const client = new LanguageServerClient(baseOptions(transport));
-        // The constructor patches resolveResponse to intercept server requests
-        expect(transport.transportRequestManager.resolveResponse).not.toBe(
-            transport.originalResolveResponse,
-        );
         await flushTicks();
         expect(client.ready).toBe(true);
 
@@ -392,15 +331,20 @@ describe("close()", () => {
         client.close();
 
         expect(client.ready).toBe(false);
+        expect(closeSpy).toHaveBeenCalled();
+
         // Server requests arriving after close are no longer answered
-        receiveFrame(transport, {
+        const responsesBefore = transport.serverResponses().length;
+        transport.receive({
             jsonrpc: "2.0",
             id: 9,
             method: "workspace/configuration",
             params: { items: [] },
         });
         await flushTicks();
-        expect(transport.sendData).not.toHaveBeenCalled();
+        expect(transport.serverResponses().length).toBe(responsesBefore);
+
+        // Listeners are cleared, so notifications no longer reach them
         // biome-ignore lint/suspicious/noExplicitAny: accessing protected member in test
         (client as any).processNotification({
             jsonrpc: "2.0",
@@ -408,29 +352,27 @@ describe("close()", () => {
             params: { uri: "file:///x", diagnostics: [] },
         });
         expect(listener).not.toHaveBeenCalled();
-        expect(clientInstances.at(-1).close).toHaveBeenCalled();
     });
 
     it("does not send initialized or become ready when closed before initialize resolves", async () => {
-        const client = new LanguageServerClient(baseOptions());
-        const internal = clientInstances.at(-1);
+        // Never auto-answer initialize, so it stays in flight until close.
+        const transport = new FakeTransport({ autoInitialize: false });
+        const client = new LanguageServerClient(baseOptions(transport));
 
-        // Close before the pending initialize response is processed
+        // Close before the pending initialize request is even sent.
         client.close();
         await flushTicks();
 
         expect(client.ready).toBe(false);
-        const initializedCalls = internal.notify.mock.calls.filter(
-            // biome-ignore lint/suspicious/noExplicitAny: inspecting mock args
-            (call: any[]) => call[0]?.method === "initialized",
-        );
-        expect(initializedCalls).toHaveLength(0);
+        expect(transport.notificationsSent("initialized")).toEqual([]);
     });
 });
 
 describe("notification listener isolation", () => {
     it("keeps notifying remaining listeners when one throws", () => {
-        const client = new LanguageServerClient(baseOptions());
+        const client = new LanguageServerClient(
+            baseOptions(new FakeTransport()),
+        );
         const bad = vi.fn().mockImplementation(() => {
             throw new Error("listener failed");
         });
@@ -453,17 +395,20 @@ describe("notification listener isolation", () => {
 
 describe("textDocumentDidClose", () => {
     it("sends a textDocument/didClose notification", async () => {
-        const client = new LanguageServerClient(baseOptions());
-        const internal = clientInstances.at(-1);
+        const transport = new FakeTransport();
+        const client = new LanguageServerClient(baseOptions(transport));
 
         await client.textDocumentDidClose({
             textDocument: { uri: "file:///x" },
         });
 
-        expect(internal.notify).toHaveBeenCalledWith({
-            method: "textDocument/didClose",
-            params: { textDocument: { uri: "file:///x" } },
-        });
+        expect(transport.notificationsSent("textDocument/didClose")).toEqual([
+            {
+                jsonrpc: "2.0",
+                method: "textDocument/didClose",
+                params: { textDocument: { uri: "file:///x" } },
+            },
+        ]);
     });
 });
 
@@ -479,30 +424,23 @@ describe("document open ref-counting", () => {
         };
     }
 
-    function countNotifications(
-        // biome-ignore lint/suspicious/noExplicitAny: inspecting mock args
-        internal: any,
-        method: string,
-    ) {
-        return internal.notify.mock.calls.filter(
-            // biome-ignore lint/suspicious/noExplicitAny: inspecting mock args
-            (call: any[]) => call[0]?.method === method,
-        ).length;
+    function notifyCount(transport: FakeTransport, method: string) {
+        return transport.notificationsSent(method).length;
     }
 
     it("sends didOpen only once when the same URI is opened twice", async () => {
-        const client = new LanguageServerClient(baseOptions());
-        const internal = clientInstances.at(-1);
+        const transport = new FakeTransport();
+        const client = new LanguageServerClient(baseOptions(transport));
 
         await client.textDocumentDidOpen(openParams("file:///dup"));
         await client.textDocumentDidOpen(openParams("file:///dup"));
 
-        expect(countNotifications(internal, "textDocument/didOpen")).toBe(1);
+        expect(notifyCount(transport, "textDocument/didOpen")).toBe(1);
     });
 
     it("sends didClose only when the last view closes", async () => {
-        const client = new LanguageServerClient(baseOptions());
-        const internal = clientInstances.at(-1);
+        const transport = new FakeTransport();
+        const client = new LanguageServerClient(baseOptions(transport));
 
         await client.textDocumentDidOpen(openParams("file:///dup"));
         await client.textDocumentDidOpen(openParams("file:///dup"));
@@ -511,27 +449,27 @@ describe("document open ref-counting", () => {
         await client.textDocumentDidClose({
             textDocument: { uri: "file:///dup" },
         });
-        expect(countNotifications(internal, "textDocument/didClose")).toBe(0);
+        expect(notifyCount(transport, "textDocument/didClose")).toBe(0);
 
         // Second close is the last reference and does notify.
         await client.textDocumentDidClose({
             textDocument: { uri: "file:///dup" },
         });
-        expect(countNotifications(internal, "textDocument/didClose")).toBe(1);
+        expect(notifyCount(transport, "textDocument/didClose")).toBe(1);
     });
 
     it("tracks distinct URIs independently", async () => {
-        const client = new LanguageServerClient(baseOptions());
-        const internal = clientInstances.at(-1);
+        const transport = new FakeTransport();
+        const client = new LanguageServerClient(baseOptions(transport));
 
         await client.textDocumentDidOpen(openParams("file:///a"));
         await client.textDocumentDidOpen(openParams("file:///b"));
 
-        expect(countNotifications(internal, "textDocument/didOpen")).toBe(2);
+        expect(notifyCount(transport, "textDocument/didOpen")).toBe(2);
 
         await client.textDocumentDidClose({
             textDocument: { uri: "file:///a" },
         });
-        expect(countNotifications(internal, "textDocument/didClose")).toBe(1);
+        expect(notifyCount(transport, "textDocument/didClose")).toBe(1);
     });
 });

--- a/src/__tests__/signatureHelpTooltipDismissal.test.ts
+++ b/src/__tests__/signatureHelpTooltipDismissal.test.ts
@@ -39,20 +39,6 @@ vi.mock("../utils.js", () => ({
     showErrorMessage: vi.fn(),
 }));
 
-// Mock the Client from @open-rpc/client-js
-vi.mock("@open-rpc/client-js", () => ({
-    Client: vi.fn().mockImplementation(() => ({
-        request: vi.fn().mockResolvedValue({}),
-        notify: vi.fn().mockResolvedValue(undefined),
-        close: vi.fn(),
-        onNotification: vi.fn(),
-        onRequest: vi.fn(),
-    })),
-    RequestManager: vi.fn().mockImplementation(() => ({
-        requestTimeoutMs: 10000,
-    })),
-}));
-
 const createMockClient = (): LanguageServerClient => {
     const mockClient = {
         ready: true,

--- a/src/__tests__/transport.test.ts
+++ b/src/__tests__/transport.test.ts
@@ -52,6 +52,11 @@ class MockSocket {
         this.fire("error", {});
     }
 
+    emitClose(): void {
+        this.readyState = MockSocket.CLOSED;
+        this.fire("close", {});
+    }
+
     private fire(type: string, event: unknown = {}): void {
         for (const listener of this.listeners.get(type) ?? []) {
             listener(event);
@@ -95,6 +100,24 @@ describe("connect", () => {
         lastSocket().emitError();
 
         await expect(connected).rejects.toThrow("ws://host/lsp");
+    });
+
+    it("rejects when the socket closes before opening", async () => {
+        const transport = new WebSocketTransport("ws://host/lsp");
+        const connected = transport.connect();
+        connected.catch(() => {});
+        lastSocket().emitClose();
+
+        await expect(connected).rejects.toThrow("closed before opening");
+    });
+
+    it("rejects a pending connection when close() is called before open", async () => {
+        const transport = new WebSocketTransport("ws://host/lsp");
+        const connected = transport.connect();
+        connected.catch(() => {});
+        transport.close();
+
+        await expect(connected).rejects.toThrow("closed");
     });
 });
 
@@ -177,10 +200,12 @@ describe("onMessage", () => {
 });
 
 describe("close", () => {
-    it("closes the socket and clears handlers", () => {
+    it("closes the socket and clears handlers", async () => {
         const transport = new WebSocketTransport("ws://host");
-        transport.connect();
+        const connected = transport.connect();
         const socket = lastSocket();
+        socket.emitOpen(); // open first so close() has no pending connect
+        await connected;
         const handler = vi.fn();
         transport.onMessage(handler);
 

--- a/src/__tests__/transport.test.ts
+++ b/src/__tests__/transport.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { JSONRPCMessage } from "../jsonrpc.js";
+import { WebSocketTransport } from "../transport.js";
+
+// biome-ignore lint/complexity/noBannedTypes: minimal event-listener registry
+type Listener = Function;
+
+/** A hand-driven stand-in for the global WebSocket. */
+class MockSocket {
+    static readonly CONNECTING = 0;
+    static readonly OPEN = 1;
+    static readonly CLOSED = 3;
+    static last: MockSocket | undefined;
+
+    readyState = MockSocket.CONNECTING;
+    closed = false;
+    readonly sent: string[] = [];
+    private readonly listeners = new Map<string, Listener[]>();
+
+    constructor(
+        readonly url: string,
+        readonly protocols?: string | string[],
+    ) {
+        MockSocket.last = this;
+    }
+
+    addEventListener(type: string, listener: Listener): void {
+        const list = this.listeners.get(type) ?? [];
+        list.push(listener);
+        this.listeners.set(type, list);
+    }
+
+    send(data: string): void {
+        this.sent.push(data);
+    }
+
+    close(): void {
+        this.closed = true;
+        this.readyState = MockSocket.CLOSED;
+    }
+
+    emitOpen(): void {
+        this.readyState = MockSocket.OPEN;
+        this.fire("open");
+    }
+
+    emitMessage(data: string): void {
+        this.fire("message", { data });
+    }
+
+    emitError(): void {
+        this.fire("error", {});
+    }
+
+    private fire(type: string, event: unknown = {}): void {
+        for (const listener of this.listeners.get(type) ?? []) {
+            listener(event);
+        }
+    }
+}
+
+beforeEach(() => {
+    MockSocket.last = undefined;
+    vi.stubGlobal("WebSocket", MockSocket);
+});
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+function lastSocket(): MockSocket {
+    if (!MockSocket.last) {
+        throw new Error("no socket was constructed");
+    }
+    return MockSocket.last;
+}
+
+describe("connect", () => {
+    it("passes url and protocols through and resolves on open", async () => {
+        const transport = new WebSocketTransport("ws://host/lsp", "lsp.v1");
+        const connected = transport.connect();
+        const socket = lastSocket();
+
+        expect(socket.url).toBe("ws://host/lsp");
+        expect(socket.protocols).toBe("lsp.v1");
+
+        socket.emitOpen();
+        await expect(connected).resolves.toBeUndefined();
+    });
+
+    it("rejects on a pre-open error", async () => {
+        const transport = new WebSocketTransport("ws://host/lsp");
+        const connected = transport.connect();
+        connected.catch(() => {});
+        lastSocket().emitError();
+
+        await expect(connected).rejects.toThrow("ws://host/lsp");
+    });
+});
+
+describe("send", () => {
+    it("buffers frames sent before open and flushes them in order", async () => {
+        const transport = new WebSocketTransport("ws://host");
+        const connected = transport.connect();
+        const socket = lastSocket();
+
+        transport.send({ jsonrpc: "2.0", id: 0, method: "a", params: {} });
+        transport.send({ jsonrpc: "2.0", method: "b", params: {} });
+        expect(socket.sent).toEqual([]); // still connecting
+
+        socket.emitOpen();
+        await connected;
+
+        expect(socket.sent).toEqual([
+            JSON.stringify({ jsonrpc: "2.0", id: 0, method: "a", params: {} }),
+            JSON.stringify({ jsonrpc: "2.0", method: "b", params: {} }),
+        ]);
+    });
+
+    it("serializes and sends immediately once open", async () => {
+        const transport = new WebSocketTransport("ws://host");
+        const connected = transport.connect();
+        const socket = lastSocket();
+        socket.emitOpen();
+        await connected;
+
+        const frame: JSONRPCMessage = {
+            jsonrpc: "2.0",
+            id: 1,
+            method: "hover",
+            params: { line: 1 },
+        };
+        transport.send(frame);
+
+        expect(socket.sent).toEqual([JSON.stringify(frame)]);
+    });
+});
+
+describe("onMessage", () => {
+    it("parses inbound JSON and dispatches to handlers", () => {
+        const transport = new WebSocketTransport("ws://host");
+        transport.connect();
+        const socket = lastSocket();
+
+        const handler = vi.fn();
+        transport.onMessage(handler);
+
+        const frame = { jsonrpc: "2.0", id: 0, result: { ok: true } };
+        socket.emitMessage(JSON.stringify(frame));
+
+        expect(handler).toHaveBeenCalledWith(frame);
+    });
+
+    it("ignores non-JSON frames", () => {
+        const transport = new WebSocketTransport("ws://host");
+        transport.connect();
+        const socket = lastSocket();
+
+        const handler = vi.fn();
+        transport.onMessage(handler);
+        expect(() => socket.emitMessage("not json {")).not.toThrow();
+        expect(handler).not.toHaveBeenCalled();
+    });
+
+    it("stops dispatching after unsubscribe", () => {
+        const transport = new WebSocketTransport("ws://host");
+        transport.connect();
+        const socket = lastSocket();
+
+        const handler = vi.fn();
+        const unsubscribe = transport.onMessage(handler);
+        unsubscribe();
+
+        socket.emitMessage(JSON.stringify({ jsonrpc: "2.0", method: "x" }));
+        expect(handler).not.toHaveBeenCalled();
+    });
+});
+
+describe("close", () => {
+    it("closes the socket and clears handlers", () => {
+        const transport = new WebSocketTransport("ws://host");
+        transport.connect();
+        const socket = lastSocket();
+        const handler = vi.fn();
+        transport.onMessage(handler);
+
+        transport.close();
+
+        expect(socket.closed).toBe(true);
+        // A late frame on the old socket reaches no one.
+        socket.emitMessage(JSON.stringify({ jsonrpc: "2.0", method: "x" }));
+        expect(handler).not.toHaveBeenCalled();
+    });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,3 +15,18 @@ export {
     languageId,
     documentUri,
 } from "./config.js";
+export { WebSocketTransport } from "./transport.js";
+export {
+    JSONRPCClient,
+    RPCError,
+    ErrorCodes,
+    type Transport,
+    type JSONRPCMessage,
+    type JSONRPCRequest,
+    type JSONRPCNotification,
+    type JSONRPCResponse,
+    type JSONRPCSuccessResponse,
+    type JSONRPCErrorResponse,
+    type JSONRPCErrorObject,
+    type RequestId,
+} from "./jsonrpc.js";

--- a/src/jsonrpc.ts
+++ b/src/jsonrpc.ts
@@ -1,0 +1,268 @@
+/**
+ * A minimal, transport-agnostic JSON-RPC 2.0 client for the Language Server
+ * Protocol. LSP is bidirectional — the server can send requests back to the
+ * client (e.g. `workspace/configuration`) — so client requests, notifications,
+ * and server-initiated requests are all first-class. A {@link Transport} owns
+ * the wire format and hands the client parsed message objects.
+ */
+
+/** A JSON-RPC request/response correlation id. */
+export type RequestId = number | string;
+
+/** A client→server or server→client request. */
+export interface JSONRPCRequest {
+    jsonrpc: "2.0";
+    id: RequestId;
+    method: string;
+    params?: unknown;
+}
+
+/** A fire-and-forget message with no response. */
+export interface JSONRPCNotification {
+    jsonrpc: "2.0";
+    method: string;
+    params?: unknown;
+}
+
+/** The `error` member of a JSON-RPC error response. */
+export interface JSONRPCErrorObject {
+    code: number;
+    message: string;
+    data?: unknown;
+}
+
+export interface JSONRPCSuccessResponse {
+    jsonrpc: "2.0";
+    id: RequestId;
+    result: unknown;
+}
+
+export interface JSONRPCErrorResponse {
+    jsonrpc: "2.0";
+    id: RequestId;
+    error: JSONRPCErrorObject;
+}
+
+export type JSONRPCResponse = JSONRPCSuccessResponse | JSONRPCErrorResponse;
+
+/** Any frame that can travel over a {@link Transport}. */
+export type JSONRPCMessage =
+    | JSONRPCRequest
+    | JSONRPCNotification
+    | JSONRPCResponse;
+
+/**
+ * Standard JSON-RPC 2.0 error codes (https://www.jsonrpc.org/specification),
+ * plus one non-standard code this client raises for client-side timeouts.
+ */
+export const ErrorCodes = {
+    ParseError: -32700,
+    InvalidRequest: -32600,
+    MethodNotFound: -32601,
+    InvalidParams: -32602,
+    InternalError: -32603,
+    /** Non-standard: a request exceeded its client-side timeout. */
+    RequestTimeout: -32001,
+} as const;
+
+/** An error carrying a JSON-RPC error code and optional structured data. */
+export class RPCError extends Error {
+    readonly code: number;
+    readonly data?: unknown;
+
+    constructor(code: number, message: string, data?: unknown) {
+        super(message);
+        this.name = "RPCError";
+        this.code = code;
+        this.data = data;
+    }
+}
+
+/**
+ * A bidirectional channel that carries JSON-RPC frames between the client and
+ * the server. Implementations own their wire format and lifecycle; the client
+ * only ever sees parsed message objects.
+ */
+export interface Transport {
+    /** Open the connection; the client awaits this once before its first send. */
+    connect(): Promise<void>;
+    /** Send a single JSON-RPC frame to the server. */
+    send(message: JSONRPCMessage): void;
+    /** Subscribe to inbound frames; the returned function unsubscribes. */
+    onMessage(handler: (message: JSONRPCMessage) => void): () => void;
+    /** Tear down the connection and release resources. */
+    close(): void;
+}
+
+const DEFAULT_TIMEOUT = 10000;
+
+interface PendingRequest {
+    resolve: (value: unknown) => void;
+    reject: (reason: unknown) => void;
+    timer: ReturnType<typeof setTimeout>;
+}
+
+function hasId(
+    message: JSONRPCMessage,
+): message is JSONRPCRequest | JSONRPCResponse {
+    const id = (message as { id?: unknown }).id;
+    return id !== undefined && id !== null;
+}
+
+function toError(value: unknown): Error {
+    return value instanceof Error
+        ? value
+        : new RPCError(ErrorCodes.InternalError, String(value));
+}
+
+/**
+ * A JSON-RPC 2.0 client over a {@link Transport}. Correlates responses to
+ * requests by id, dispatches inbound notifications and server-initiated
+ * requests to registered handlers, and enforces per-request timeouts.
+ */
+export class JSONRPCClient {
+    private readonly transport: Transport;
+    private readonly pending = new Map<RequestId, PendingRequest>();
+    private readonly disconnect: () => void;
+    private readonly connected: Promise<void>;
+    private nextId = 0;
+    private closed = false;
+    private notificationHandler?: (notification: JSONRPCNotification) => void;
+    private requestHandler?: (request: JSONRPCRequest) => void;
+
+    constructor(transport: Transport) {
+        this.transport = transport;
+        this.disconnect = transport.onMessage((message) =>
+            this.receive(message),
+        );
+        this.connected = transport.connect();
+        // A connection failure surfaces on the first request/notification;
+        // swallow it here so it is never an unhandled rejection on its own.
+        this.connected.catch(() => {});
+    }
+
+    /** Register the handler invoked for each inbound notification. */
+    onNotification(handler: (notification: JSONRPCNotification) => void): void {
+        this.notificationHandler = handler;
+    }
+
+    /** Register the handler invoked for each server→client request. */
+    onRequest(handler: (request: JSONRPCRequest) => void): void {
+        this.requestHandler = handler;
+    }
+
+    /**
+     * Send a request and resolve with its result. Rejects with an
+     * {@link RPCError} if the server returns an error, the request times out,
+     * or the client is closed while it is in flight.
+     */
+    request(
+        method: string,
+        params: unknown,
+        timeout: number = DEFAULT_TIMEOUT,
+    ): Promise<unknown> {
+        const id = this.nextId++;
+        return new Promise<unknown>((resolve, reject) => {
+            const timer = setTimeout(() => {
+                this.pending.delete(id);
+                reject(
+                    new RPCError(
+                        ErrorCodes.RequestTimeout,
+                        `Request "${method}" timed out after ${timeout}ms`,
+                    ),
+                );
+            }, timeout);
+            this.pending.set(id, { resolve, reject, timer });
+            this.connected.then(
+                () => {
+                    // The request may have timed out or been closed while
+                    // connecting; only send if it is still pending.
+                    if (this.pending.has(id)) {
+                        this.transport.send({
+                            jsonrpc: "2.0",
+                            id,
+                            method,
+                            params,
+                        });
+                    }
+                },
+                (error) => this.settle(id, (p) => p.reject(toError(error))),
+            );
+        });
+    }
+
+    /** Send a fire-and-forget notification. */
+    notify(method: string, params: unknown): Promise<void> {
+        return this.dispatch({ jsonrpc: "2.0", method, params });
+    }
+
+    /** Send a response to a server-initiated request. */
+    respond(response: JSONRPCResponse): Promise<void> {
+        return this.dispatch(response);
+    }
+
+    /** Reject all in-flight requests and tear down the transport. */
+    close(): void {
+        if (this.closed) {
+            return;
+        }
+        this.closed = true;
+        for (const pending of this.pending.values()) {
+            clearTimeout(pending.timer);
+            pending.reject(
+                new RPCError(ErrorCodes.InternalError, "Client closed"),
+            );
+        }
+        this.pending.clear();
+        this.disconnect();
+        this.transport.close();
+    }
+
+    /** Send once the transport is connected. */
+    private dispatch(message: JSONRPCMessage): Promise<void> {
+        return this.connected.then(() => this.transport.send(message));
+    }
+
+    private settle(id: RequestId, handle: (pending: PendingRequest) => void) {
+        const pending = this.pending.get(id);
+        if (!pending) {
+            return;
+        }
+        clearTimeout(pending.timer);
+        this.pending.delete(id);
+        handle(pending);
+    }
+
+    private receive(message: JSONRPCMessage): void {
+        if (this.closed || message == null || typeof message !== "object") {
+            return;
+        }
+        // A frame with a method is a request (has an id) or a notification (no
+        // id); anything else correlates to a pending request by id.
+        if (typeof (message as { method?: unknown }).method === "string") {
+            if (hasId(message)) {
+                this.requestHandler?.(message as JSONRPCRequest);
+            } else {
+                this.notificationHandler?.(message as JSONRPCNotification);
+            }
+            return;
+        }
+        if (!hasId(message)) {
+            return;
+        }
+        const response = message as JSONRPCResponse;
+        this.settle(response.id, (pending) => {
+            if ("error" in response && response.error) {
+                pending.reject(
+                    new RPCError(
+                        response.error.code,
+                        response.error.message,
+                        response.error.data,
+                    ),
+                );
+            } else {
+                pending.resolve((response as JSONRPCSuccessResponse).result);
+            }
+        });
+    }
+}

--- a/src/jsonrpc.ts
+++ b/src/jsonrpc.ts
@@ -161,6 +161,11 @@ export class JSONRPCClient {
         params: unknown,
         timeout: number = DEFAULT_TIMEOUT,
     ): Promise<unknown> {
+        if (this.closed) {
+            return Promise.reject(
+                new RPCError(ErrorCodes.InternalError, "Client closed"),
+            );
+        }
         const id = this.nextId++;
         return new Promise<unknown>((resolve, reject) => {
             const timer = setTimeout(() => {
@@ -177,13 +182,18 @@ export class JSONRPCClient {
                 () => {
                     // The request may have timed out or been closed while
                     // connecting; only send if it is still pending.
-                    if (this.pending.has(id)) {
+                    if (!this.pending.has(id)) {
+                        return;
+                    }
+                    try {
                         this.transport.send({
                             jsonrpc: "2.0",
                             id,
                             method,
                             params,
                         });
+                    } catch (error) {
+                        this.settle(id, (p) => p.reject(toError(error)));
                     }
                 },
                 (error) => this.settle(id, (p) => p.reject(toError(error))),
@@ -218,8 +228,11 @@ export class JSONRPCClient {
         this.transport.close();
     }
 
-    /** Send once the transport is connected. */
+    /** Send once the transport is connected; a no-op once closed. */
     private dispatch(message: JSONRPCMessage): Promise<void> {
+        if (this.closed) {
+            return Promise.resolve();
+        }
         return this.connected.then(() => this.transport.send(message));
     }
 

--- a/src/jsonrpc.ts
+++ b/src/jsonrpc.ts
@@ -228,12 +228,17 @@ export class JSONRPCClient {
         this.transport.close();
     }
 
-    /** Send once the transport is connected; a no-op once closed. */
+    /** Send once the transport is connected; a no-op if closed meanwhile. */
     private dispatch(message: JSONRPCMessage): Promise<void> {
         if (this.closed) {
             return Promise.resolve();
         }
-        return this.connected.then(() => this.transport.send(message));
+        return this.connected.then(() => {
+            // close() may have torn down the transport while connecting.
+            if (!this.closed) {
+                this.transport.send(message);
+            }
+        });
     }
 
     private settle(id: RequestId, handle: (pending: PendingRequest) => void) {

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -1,14 +1,15 @@
 import type { autocompletion } from "@codemirror/autocomplete";
 import type { hoverTooltip } from "@codemirror/view";
-import { Client, RequestManager } from "@open-rpc/client-js";
-import type { Transport } from "@open-rpc/client-js/build/transports/Transport.js";
 import type * as LSP from "vscode-languageserver-protocol";
+import {
+    ErrorCodes,
+    JSONRPCClient,
+    type JSONRPCRequest,
+    type JSONRPCResponse,
+    type Transport,
+} from "./jsonrpc.js";
 
 const TIMEOUT = 10000;
-
-// JSON-RPC error codes (https://www.jsonrpc.org/specification#error_object)
-const METHOD_NOT_FOUND = -32601;
-const INTERNAL_ERROR = -32603;
 
 // Client to server then server to client
 export interface LSPRequestMap {
@@ -76,48 +77,6 @@ export type Notification = {
 export type ServerRequestHandler<P = any, R = any> = (
     params: P,
 ) => Promise<R> | R;
-
-/** An incoming server->client JSON-RPC request frame */
-interface ServerRequest {
-    jsonrpc: "2.0";
-    id: number | string;
-    method: string;
-    params?: unknown;
-}
-
-interface JsonRpcResponse {
-    jsonrpc: "2.0";
-    id: number | string;
-    result?: unknown;
-    error?: { code: number; message: string };
-}
-
-function isServerRequest(frame: unknown): frame is ServerRequest {
-    if (frame == null || typeof frame !== "object" || Array.isArray(frame)) {
-        return false;
-    }
-    const candidate = frame as Partial<ServerRequest>;
-    // A JSON-RPC id of 0 is valid, so check for presence, not truthiness;
-    // frames with a method but no id are notifications, not requests
-    return (
-        typeof candidate.method === "string" &&
-        candidate.id !== undefined &&
-        candidate.id !== null
-    );
-}
-
-/**
- * Every @open-rpc/client-js transport funnels each incoming frame through its
- * TransportRequestManager, which silently drops server->client requests (and
- * can even mistake them for responses to in-flight client requests when ids
- * collide). The manager is the only transport-agnostic seam, so we access it
- * through this narrowed shape.
- */
-interface InterceptableTransport {
-    transportRequestManager?: {
-        resolveResponse(payload: string, emitError?: boolean): unknown;
-    };
-}
 
 /**
  * Maps client->server request methods to the static server capability that
@@ -303,9 +262,7 @@ export class LanguageServerClient {
     private workspaceFolders: LSP.WorkspaceFolder[] | null;
     private timeout: number;
 
-    private transport: Transport;
-    private requestManager: RequestManager;
-    private client: Client;
+    private client: JSONRPCClient;
     private initializationOptions: LanguageServerClientOptions["initializationOptions"];
     public clientCapabilities: LanguageServerClientOptions["capabilities"];
 
@@ -329,8 +286,6 @@ export class LanguageServerClient {
      * server announced it statically or dynamically.
      */
     public dynamicCapabilities = new Map<string, LSP.Registration>();
-    private detachServerRequestInterceptor?: () => void;
-    private serverResponseCount = 0;
     private isClosed = false;
 
     constructor({
@@ -344,21 +299,19 @@ export class LanguageServerClient {
     }: LanguageServerClientOptions) {
         this.rootUri = rootUri;
         this.workspaceFolders = workspaceFolders;
-        this.transport = transport;
         this.initializationOptions = initializationOptions;
         this.clientCapabilities = capabilities;
         this.timeout = timeout;
         this.ready = false;
         this.capabilities = null;
-        this.requestManager = new RequestManager([this.transport]);
-        this.client = new Client(this.requestManager);
+        this.client = new JSONRPCClient(transport);
 
-        this.client.onNotification((data) => {
-            this.processNotification(data as Notification);
+        this.client.onNotification((notification) => {
+            this.processNotification(notification as unknown as Notification);
         });
-
-        this.detachServerRequestInterceptor =
-            this.attachServerRequestInterceptor(this.transport);
+        this.client.onRequest((request) => {
+            void this.handleServerRequest(request);
+        });
 
         this.onRequest(
             "workspace/configuration",
@@ -570,8 +523,6 @@ export class LanguageServerClient {
         this.notificationListeners.clear();
         this.serverRequestHandlers.clear();
         this.dynamicCapabilities.clear();
-        this.detachServerRequestInterceptor?.();
-        this.detachServerRequestInterceptor = undefined;
         this.client.close();
     }
 
@@ -616,50 +567,20 @@ export class LanguageServerClient {
     }
 
     /**
-     * Patches the transport's TransportRequestManager so server->client
-     * requests are dispatched to {@link serverRequestHandlers} instead of
-     * being silently dropped (or, worse, matched against a pending client
-     * request with a colliding id). Responses and notifications still flow
-     * through the original code path untouched.
+     * Answers a server-initiated request by running its registered handler and
+     * sending the result (or error) back to the server. Requests with no
+     * handler get a spec-compliant `MethodNotFound` so servers can fall back
+     * gracefully.
      */
-    private attachServerRequestInterceptor(
-        transport: Transport,
-    ): (() => void) | undefined {
-        const manager = (transport as unknown as InterceptableTransport)
-            .transportRequestManager;
-        if (!manager || typeof manager.resolveResponse !== "function") {
-            return undefined;
-        }
-        const original = manager.resolveResponse.bind(manager);
-        manager.resolveResponse = (payload: string, emitError?: boolean) => {
-            if (typeof payload === "string") {
-                let frame: unknown;
-                try {
-                    frame = JSON.parse(payload);
-                } catch {
-                    frame = undefined;
-                }
-                if (isServerRequest(frame)) {
-                    void this.handleServerRequest(frame);
-                    return undefined;
-                }
-            }
-            return original(payload, emitError);
-        };
-        return () => {
-            manager.resolveResponse = original;
-        };
-    }
-
-    private async handleServerRequest(request: ServerRequest): Promise<void> {
+    private async handleServerRequest(request: JSONRPCRequest): Promise<void> {
         const handler = this.serverRequestHandlers.get(request.method);
-        let response: JsonRpcResponse;
+        let response: JSONRPCResponse;
         if (!handler) {
             response = {
                 jsonrpc: "2.0",
                 id: request.id,
                 error: {
-                    code: METHOD_NOT_FOUND,
+                    code: ErrorCodes.MethodNotFound,
                     message: `Method not found: ${request.method}`,
                 },
             };
@@ -669,8 +590,8 @@ export class LanguageServerClient {
                 response = {
                     jsonrpc: "2.0",
                     id: request.id,
-                    // JSON.stringify drops `result: undefined`, which would
-                    // produce a spec-invalid response; send an explicit null
+                    // A JSON-RPC result member is required; coerce a handler's
+                    // undefined to an explicit null.
                     result: result === undefined ? null : result,
                 };
             } catch (error) {
@@ -678,7 +599,7 @@ export class LanguageServerClient {
                     jsonrpc: "2.0",
                     id: request.id,
                     error: {
-                        code: INTERNAL_ERROR,
+                        code: ErrorCodes.InternalError,
                         message:
                             error instanceof Error
                                 ? error.message
@@ -690,21 +611,7 @@ export class LanguageServerClient {
         if (this.isClosed) {
             return;
         }
-        // sendData wraps outgoing payloads in {internalID, request} and sends
-        // `request` verbatim, so a raw response object rides through any
-        // transport. Because the response carries an id, the transport tracks
-        // it as if it were a request awaiting an answer that never comes; the
-        // timeout cleans up that entry and the rejection is expected.
-        const internalID = `codemirror-languageserver:server-reply:${this.serverResponseCount++}`;
-        try {
-            await this.transport.sendData(
-                // biome-ignore lint/suspicious/noExplicitAny: a response frame is not part of JSONRPCRequestData
-                { internalID, request: response as any },
-                this.timeout,
-            );
-        } catch {
-            // Expected: responses get no acknowledgement
-        }
+        void this.client.respond(response);
     }
 
     public textDocumentDidOpen(params: LSP.DidOpenTextDocumentParams) {
@@ -818,14 +725,16 @@ export class LanguageServerClient {
         params: LSPRequestMap[K][0],
         timeout: number,
     ): Promise<LSPRequestMap[K][1]> {
-        return this.client.request({ method, params }, timeout);
+        return this.client.request(method, params, timeout) as Promise<
+            LSPRequestMap[K][1]
+        >;
     }
 
     protected notify<K extends keyof LSPNotifyMap>(
         method: K,
         params: LSPNotifyMap[K],
-    ): Promise<LSPNotifyMap[K]> {
-        return this.client.notify({ method, params });
+    ): Promise<void> {
+        return this.client.notify(method, params);
     }
 
     protected processNotification(notification: Notification) {

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -611,7 +611,9 @@ export class LanguageServerClient {
         if (this.isClosed) {
             return;
         }
-        void this.client.respond(response);
+        // An async handler may finish after the transport closed; swallow the
+        // resulting send failure so teardown is not an unhandled rejection.
+        void this.client.respond(response).catch(() => {});
     }
 
     public textDocumentDidOpen(params: LSP.DidOpenTextDocumentParams) {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -13,7 +13,6 @@ import {
     keymap,
     showTooltip,
 } from "@codemirror/view";
-import { WebSocketTransport } from "@open-rpc/client-js";
 import {
     CompletionTriggerKind,
     DiagnosticSeverity,
@@ -49,6 +48,7 @@ import {
     type LanguageServerWebsocketOptions,
     type Notification,
 } from "./lsp.js";
+import { WebSocketTransport } from "./transport.js";
 import {
     eventsFromChangeSet,
     isCompletionList,

--- a/src/testing/fakeTransport.ts
+++ b/src/testing/fakeTransport.ts
@@ -1,0 +1,85 @@
+import type { JSONRPCMessage, Transport } from "../jsonrpc.js";
+
+export interface FakeTransportOptions {
+    /** Capabilities returned for the `initialize` handshake. */
+    capabilities?: Record<string, unknown>;
+    /** When set, `initialize` is answered with this JSON-RPC error instead. */
+    failInitialize?: { code: number; message: string };
+    /**
+     * Auto-answer the `initialize` handshake so the client reaches `ready`.
+     * @default true
+     */
+    autoInitialize?: boolean;
+}
+
+/**
+ * An in-memory {@link Transport} for tests. Records every frame the client
+ * sends, lets a test inject inbound frames via {@link receive}, and (by
+ * default) auto-answers the `initialize` handshake so the client becomes ready.
+ */
+export class FakeTransport implements Transport {
+    /** Every frame the client has sent, in order. */
+    readonly sent: JSONRPCMessage[] = [];
+    private readonly handlers = new Set<(message: JSONRPCMessage) => void>();
+
+    constructor(private readonly options: FakeTransportOptions = {}) {}
+
+    connect(): Promise<void> {
+        return Promise.resolve();
+    }
+
+    send(message: JSONRPCMessage): void {
+        this.sent.push(message);
+        const auto = this.options.autoInitialize ?? true;
+        if (
+            auto &&
+            "id" in message &&
+            "method" in message &&
+            message.method === "initialize"
+        ) {
+            const { failInitialize, capabilities } = this.options;
+            this.receive(
+                failInitialize
+                    ? { jsonrpc: "2.0", id: message.id, error: failInitialize }
+                    : {
+                          jsonrpc: "2.0",
+                          id: message.id,
+                          result: { capabilities: capabilities ?? {} },
+                      },
+            );
+        }
+    }
+
+    onMessage(handler: (message: JSONRPCMessage) => void): () => void {
+        this.handlers.add(handler);
+        return () => {
+            this.handlers.delete(handler);
+        };
+    }
+
+    close(): void {
+        this.handlers.clear();
+    }
+
+    /** Deliver an inbound (server→client) frame to the client. */
+    receive(message: JSONRPCMessage): void {
+        for (const handler of this.handlers) {
+            handler(message);
+        }
+    }
+
+    /** Frames the client sent in reply to server→client requests. */
+    serverResponses(): JSONRPCMessage[] {
+        return this.sent.filter((m) => "id" in m && !("method" in m));
+    }
+
+    /** Notifications the client sent, optionally filtered by method. */
+    notificationsSent(method?: string): JSONRPCMessage[] {
+        return this.sent.filter(
+            (m) =>
+                "method" in m &&
+                !("id" in m) &&
+                (method === undefined || m.method === method),
+        );
+    }
+}

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -9,6 +9,8 @@ export class WebSocketTransport implements Transport {
     private readonly url: string;
     private readonly protocols?: string | string[];
     private socket?: WebSocket;
+    private opened = false;
+    private rejectConnect?: (reason: unknown) => void;
     private readonly handlers = new Set<(message: JSONRPCMessage) => void>();
     private outbox: string[] = [];
 
@@ -21,8 +23,11 @@ export class WebSocketTransport implements Transport {
         return new Promise<void>((resolve, reject) => {
             const socket = new WebSocket(this.url, this.protocols);
             this.socket = socket;
+            this.rejectConnect = reject;
 
             socket.addEventListener("open", () => {
+                this.opened = true;
+                this.rejectConnect = undefined;
                 for (const frame of this.outbox) {
                     socket.send(frame);
                 }
@@ -43,10 +48,20 @@ export class WebSocketTransport implements Transport {
                 }
             });
 
-            // Rejects only a pre-open failure; after `open` resolved, this is
-            // a no-op.
+            // An error or a close before `open` rejects connect() so awaiters
+            // (JSONRPCClient.connected) never hang; after `open`, reject is a
+            // no-op.
             socket.addEventListener("error", () => {
                 reject(new Error(`WebSocket connection to ${this.url} failed`));
+            });
+            socket.addEventListener("close", () => {
+                if (!this.opened) {
+                    reject(
+                        new Error(
+                            `WebSocket to ${this.url} closed before opening`,
+                        ),
+                    );
+                }
             });
         });
     }
@@ -68,6 +83,9 @@ export class WebSocketTransport implements Transport {
     }
 
     close(): void {
+        // Settle a still-pending connect() so its awaiters don't hang forever.
+        this.rejectConnect?.(new Error(`WebSocket to ${this.url} closed`));
+        this.rejectConnect = undefined;
         this.handlers.clear();
         this.outbox = [];
         this.socket?.close();

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -1,0 +1,76 @@
+import type { JSONRPCMessage, Transport } from "./jsonrpc.js";
+
+/**
+ * A {@link Transport} that speaks JSON-RPC over a WebSocket, one JSON frame per
+ * message (the framing LSP web bridges use). Frames sent before the socket
+ * opens are buffered and flushed on `open`.
+ */
+export class WebSocketTransport implements Transport {
+    private readonly url: string;
+    private readonly protocols?: string | string[];
+    private socket?: WebSocket;
+    private readonly handlers = new Set<(message: JSONRPCMessage) => void>();
+    private outbox: string[] = [];
+
+    constructor(url: string, protocols?: string | string[]) {
+        this.url = url;
+        this.protocols = protocols;
+    }
+
+    connect(): Promise<void> {
+        return new Promise<void>((resolve, reject) => {
+            const socket = new WebSocket(this.url, this.protocols);
+            this.socket = socket;
+
+            socket.addEventListener("open", () => {
+                for (const frame of this.outbox) {
+                    socket.send(frame);
+                }
+                this.outbox = [];
+                resolve();
+            });
+
+            socket.addEventListener("message", (event: MessageEvent) => {
+                let message: JSONRPCMessage;
+                try {
+                    message = JSON.parse(String(event.data));
+                } catch {
+                    // Ignore frames that are not valid JSON.
+                    return;
+                }
+                for (const handler of this.handlers) {
+                    handler(message);
+                }
+            });
+
+            // Rejects only a pre-open failure; after `open` resolved, this is
+            // a no-op.
+            socket.addEventListener("error", () => {
+                reject(new Error(`WebSocket connection to ${this.url} failed`));
+            });
+        });
+    }
+
+    send(message: JSONRPCMessage): void {
+        const frame = JSON.stringify(message);
+        if (this.socket && this.socket.readyState === WebSocket.OPEN) {
+            this.socket.send(frame);
+        } else {
+            this.outbox.push(frame);
+        }
+    }
+
+    onMessage(handler: (message: JSONRPCMessage) => void): () => void {
+        this.handlers.add(handler);
+        return () => {
+            this.handlers.delete(handler);
+        };
+    }
+
+    close(): void {
+        this.handlers.clear();
+        this.outbox = [];
+        this.socket?.close();
+        this.socket = undefined;
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,5 +20,10 @@
         "outDir": "./dist"
     },
     "include": ["./src"],
-    "exclude": ["./demo", "./src/**/*.test.ts"]
+    "exclude": [
+        "./demo",
+        "./src/**/*.test.ts",
+        "./src/testing",
+        "./src/__tests__"
+    ]
 }


### PR DESCRIPTION
## Summary

Replaces the `@open-rpc/client-js` dependency with a small, transport-agnostic **JSON-RPC 2.0 client tailored for LSP's bidirectional traffic**. Net **+346 / −732** across the tracked diff (the new source files are the additions).

## Why

The library was already fighting the dependency. Two hacks in `lsp.ts` existed *only* because `@open-rpc/client-js` models unidirectional OpenRPC, not bidirectional LSP:

1. A monkey-patch of the transport's internal `transportRequestManager.resolveResponse` to intercept server→client requests (which the library otherwise silently drops).
2. A raw `sendData({internalID, request})` abuse to push responses back, with its inevitable timeout rejection swallowed.

It also dragged in Node-only polyfills irrelevant to a browser CodeMirror plugin — `node-fetch`, `whatwg-fetch`, `ws@7` (via `isomorphic-fetch` / `isomorphic-ws`).

A purpose-built client makes server→client requests and responses first-class, so **both hacks are deleted** and `lsp.ts` shrinks ~150 lines.

## What

- **`src/jsonrpc.ts`** — `JSONRPCClient` + a clean object-based `Transport` interface (`connect`/`send`/`onMessage`/`close`), `RPCError`/`ErrorCodes`, and JSON-RPC message types. Correlates responses by id, per-request timeouts, and routes notifications + server-initiated requests to registered handlers.
- **`src/transport.ts`** — `WebSocketTransport` (one JSON frame per message, queue-until-open).
- **Public API** — `index.ts` now exports `WebSocketTransport`, the `Transport` type, `RPCError`, `ErrorCodes`, and the message types, so consumers build custom transports without importing a third-party package.
- **Demos migrated** — `WorkerTransport` and `MockTransport` reimplemented on the new interface (they're the reference examples).

## ⚠️ Breaking change

The transport contract moved off `@open-rpc/client-js`. Custom transports (e.g. marimo's) must implement the new `Transport` interface instead of extending open-rpc's `Transport` base class. **Ship as a major.** A thin compat shim over the old base class would ease marimo's migration if wanted.

> Also note: the internal `JSONRPCClient.request(method, params, timeout)` signature differs from open-rpc's `request({method, params}, timeout)` — not public API, but it's why a few test assertions changed.

## Dependency cleanup (`dependencies` 7 → 2)

| Package | Before → After | Why |
|---|---|---|
| `@codemirror/autocomplete`, `@codemirror/lint` | dep → **peerDep** (+dev) | CodeMirror packages; consumer provides — avoids duplicate-instance breakage |
| `@astral-sh/ruff-wasm-web`, `@codemirror/lang-python`, `@typescript/vfs` | dep → **devDep** | demo-only, never imported by `src/` |
| `events` | devDep → **removed** | dead leftover (open-rpc EventEmitter polyfill) |
| `marked`, `vscode-languageserver-protocol` | kept as **dep** | genuine runtime needs (markdown renderer; LSP enum values) |

## Tests

- New direct unit tests for `JSONRPCClient` and `WebSocketTransport` (coverage: jsonrpc.ts **85%→98%**, transport.ts **50%→100%**).
- Existing tests migrated off open-rpc mocks onto a shared, build-excluded `src/testing/fakeTransport.ts` — driving behavior through the real client instead of a mocked internal.
- A read-only dead-code audit confirmed no orphaned code, unused imports, or open-rpc leftovers.

**All green:** `frozen install` · `typecheck` · `lint:ci` · **428 tests** · `build` (dist clean) · `build:demo`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces `@open-rpc/client-js` with a small, bidirectional JSON-RPC 2.0 client tailored for LSP, removing hacks and cutting dependencies. Adds guards around connect/close so queued notifications/responses don’t fire after teardown and pending requests settle cleanly.

- **New Features**
  - Added `JSONRPCClient` with server→client request handling and per-request timeouts.
  - Introduced a minimal `Transport` interface and exported `WebSocketTransport`, `RPCError`, `ErrorCodes`, and JSON-RPC types from `index.ts`.
  - Updated demos to use `WorkerTransport` and a mock transport on the new interface; removed `@open-rpc/client-js` and Node-only polyfills; moved `@codemirror/autocomplete` and `@codemirror/lint` to peer deps.

- **Migration**
  - Breaking: custom transports must implement the new `Transport` interface (`connect`, `send`, `onMessage`, `close`) instead of extending open-rpc’s `Transport`.
  - Internal API: requests are now `request(method, params, timeout)` (not `{ method, params }`).
  - Release as a major.

<sup>Written for commit 31767ea0b8c256d09d07b1916d7f2a83ed6a4fad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marimo-team/codemirror-languageserver/pull/81?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

