### PR TITLE
feat: codeAction/resolve and a cursor-triggered code action menu (Mod-.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,11 +132,17 @@ actions directly through the plugin:
 import { getLanguageServerPlugin } from '@marimo-team/codemirror-languageserver';
 
 const plugin = getLanguageServerPlugin(view);
-const actions = await plugin?.requestCodeActions(view, range, [
-  'source.organizeImports',
-]);
-if (actions?.[0]) {
-  await plugin.applyCodeAction(actions[0]);
+if (plugin) {
+  const wholeDocument = {
+    start: { line: 0, character: 0 },
+    end: { line: view.state.doc.lines - 1, character: 0 },
+  };
+  const actions = await plugin.requestCodeActions(view, wholeDocument, [
+    'source.organizeImports',
+  ]);
+  if (actions?.[0]) {
+    await plugin.applyCodeAction(actions[0]);
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ const view = new EditorView({
 - `F2` - Rename symbol under cursor
 - `Ctrl/Cmd + Click` - Go to definition
 - `Ctrl/Cmd + Space` - Trigger completion manually
+- `Ctrl/Cmd + .` - Open the code action menu at the cursor/selection
 
 ## Advanced Configuration
 
@@ -96,6 +97,46 @@ shown with a strikethrough by default. Override with:
 .cm-tooltip-autocomplete li.cm-deprecated .cm-completionLabel {
   text-decoration: line-through;
   opacity: 0.7;
+}
+```
+
+### Code Actions
+
+Pressing `Ctrl/Cmd + .` (configurable via `keyboardShortcuts.codeActions`)
+requests code actions for the current selection — including refactors and
+source actions not tied to a diagnostic — and shows them in a small menu at
+the cursor. Actions the server provides lazily (without an edit) are resolved
+via `codeAction/resolve` before being applied.
+
+Hosts can replace the built-in menu with their own UI:
+
+```typescript
+const ls = languageServer({
+  // ...
+  codeActionsConfig: {
+    renderMenu: (actions, apply) => {
+      // Render your own menu; call apply(action) with the chosen action.
+      myMenu.show(actions.map((a) => ({
+        label: a.title,
+        onSelect: () => apply(a),
+      })));
+    },
+  },
+});
+```
+
+Custom entry points (e.g. an "Organize imports" button) can request filtered
+actions directly through the plugin:
+
+```typescript
+import { getLanguageServerPlugin } from '@marimo-team/codemirror-languageserver';
+
+const plugin = getLanguageServerPlugin(view);
+const actions = await plugin?.requestCodeActions(view, range, [
+  'source.organizeImports',
+]);
+if (actions?.[0]) {
+  await plugin.applyCodeAction(actions[0]);
 }
 ```
 

--- a/demo/mock/mockDemo.ts
+++ b/demo/mock/mockDemo.ts
@@ -91,6 +91,8 @@ class MockTransport implements Transport {
                     return reply(await server.rename(params));
                 case "textDocument/codeAction":
                     return reply(await server.codeAction(params));
+                case "codeAction/resolve":
+                    return reply(await server.codeActionResolve(params));
                 case "textDocument/signatureHelp":
                     return reply(await server.signatureHelp(params));
             }
@@ -122,6 +124,7 @@ const SAMPLE = `// CodeMirror LSP Demo (in-memory mock server)
 // 2. Press F2 to rename
 // 3. Ctrl/Cmd+Click for definition
 // 4. Type 'console.' for completion
+// 5. Press Ctrl/Cmd+. for code actions (try "Convert line to uppercase")
 
 function example() {
     console.log("Hello, World!");

--- a/demo/mockLSP.ts
+++ b/demo/mockLSP.ts
@@ -54,7 +54,12 @@ export class MockLSPServer {
                 referencesProvider: true,
                 documentSymbolProvider: true,
                 codeActionProvider: {
-                    codeActionKinds: ["quickfix"],
+                    codeActionKinds: [
+                        "quickfix",
+                        "refactor.rewrite",
+                        "refactor.extract",
+                    ],
+                    resolveProvider: true,
                 },
                 renameProvider: {
                     prepareProvider: true,
@@ -354,22 +359,86 @@ export class MockLSPServer {
     public async codeAction(
         params: LSP.CodeActionParams,
     ): Promise<LSP.CodeAction[]> {
-        // Return mock code actions for diagnostics
-        return params.context.diagnostics.map((diagnostic) => ({
-            title: `Fix: ${diagnostic.message}`,
-            kind: "quickfix",
-            diagnostics: [diagnostic],
+        const quickFixes: LSP.CodeAction[] = params.context.diagnostics.map(
+            (diagnostic) => ({
+                title: `Fix: ${diagnostic.message}`,
+                kind: "quickfix",
+                diagnostics: [diagnostic],
+                edit: {
+                    changes: {
+                        [params.textDocument.uri]: [
+                            {
+                                range: diagnostic.range,
+                                newText: "/* Fixed */",
+                            },
+                        ],
+                    },
+                },
+            }),
+        );
+
+        // Refactors not tied to any diagnostic
+        const refactors: LSP.CodeAction[] = [
+            {
+                title: "Convert line to uppercase",
+                kind: "refactor.rewrite",
+                // No edit here: the client must call codeAction/resolve
+                data: {
+                    uri: params.textDocument.uri,
+                    line: params.range.start.line,
+                },
+            },
+            {
+                title: "Extract function",
+                kind: "refactor.extract",
+                disabled: { reason: "Not extractable in the mock server" },
+            },
+        ];
+
+        const actions = [...quickFixes, ...refactors];
+        const only = params.context.only;
+        if (only && only.length > 0) {
+            return actions.filter(
+                (action) =>
+                    action.kind &&
+                    only.some(
+                        (kind) =>
+                            action.kind === kind ||
+                            action.kind?.startsWith(`${kind}.`),
+                    ),
+            );
+        }
+        return actions;
+    }
+
+    public async codeActionResolve(
+        action: LSP.CodeAction,
+    ): Promise<LSP.CodeAction> {
+        const data = action.data as { uri?: string; line?: number } | undefined;
+        if (!data?.uri || data.line == null) {
+            return action;
+        }
+        const text = this.documents.get(data.uri) ?? "";
+        const lineText = text.split("\n")[data.line] ?? "";
+        return {
+            ...action,
             edit: {
                 changes: {
-                    [params.textDocument.uri]: [
+                    [data.uri]: [
                         {
-                            range: diagnostic.range,
-                            newText: "/* Fixed */",
+                            range: {
+                                start: { line: data.line, character: 0 },
+                                end: {
+                                    line: data.line,
+                                    character: lineText.length,
+                                },
+                            },
+                            newText: lineText.toUpperCase(),
                         },
                     ],
                 },
             },
-        }));
+        };
     }
 
     // Default signature help data that can be reused

--- a/src/__tests__/code-actions.test.ts
+++ b/src/__tests__/code-actions.test.ts
@@ -197,6 +197,54 @@ describe("applyCodeAction / codeAction/resolve", () => {
 
         expect(view.state.doc.toString()).toBe("hello there");
     });
+
+    it("applies all documentChanges entries for this document in one transaction", async () => {
+        const client = createFakeClient();
+        const view = createView("hello world");
+        const plugin = createPlugin(view, client);
+
+        await plugin.applyCodeAction({
+            title: "Fix it",
+            edit: {
+                documentChanges: [
+                    {
+                        textDocument: { uri: DOCUMENT_URI, version: 1 },
+                        edits: [{ range: range(0, 0, 0, 5), newText: "howdy" }],
+                    },
+                    {
+                        textDocument: { uri: DOCUMENT_URI, version: 1 },
+                        edits: [
+                            { range: range(0, 6, 0, 11), newText: "there" },
+                        ],
+                    },
+                ],
+            },
+        });
+
+        expect(view.state.doc.toString()).toBe("howdy there");
+    });
+
+    it("resolves via a dynamically registered codeAction provider", async () => {
+        const client = createFakeClient({
+            capabilities: { codeActionProvider: true },
+        });
+        client.dynamicCapabilities.set("reg-1", {
+            id: "reg-1",
+            method: "textDocument/codeAction",
+            registerOptions: { resolveProvider: true },
+        });
+        client.codeActionResolve = vi.fn().mockResolvedValue({
+            title: "Fix it",
+            edit: editReplacing(range(0, 0, 0, 5), "fixed"),
+        });
+        const view = createView("hello world");
+        const plugin = createPlugin(view, client);
+
+        await plugin.applyCodeAction({ title: "Fix it" });
+
+        expect(client.codeActionResolve).toHaveBeenCalled();
+        expect(view.state.doc.toString()).toBe("fixed world");
+    });
 });
 
 describe("requestCodeActionsAtSelection", () => {
@@ -308,8 +356,9 @@ describe("batched diagnostics code actions", () => {
             range: range(0, 0, 0, 5),
             message: "first",
         };
+        // Adjacent to first (ranges are end-exclusive): must not overlap
         const second: LSP.Diagnostic = {
-            range: range(0, 6, 0, 11),
+            range: range(0, 5, 0, 11),
             message: "second",
         };
         const client = createFakeClient({

--- a/src/__tests__/code-actions.test.ts
+++ b/src/__tests__/code-actions.test.ts
@@ -1,0 +1,484 @@
+import { setDiagnostics } from "@codemirror/lint";
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type * as LSP from "vscode-languageserver-protocol";
+import { LanguageServerClient } from "../lsp.js";
+import type { FeatureOptions } from "../lsp.js";
+import { LanguageServerPlugin } from "../plugin.js";
+
+const DOCUMENT_URI = "file:///test.ts";
+
+const featureOptions: Required<FeatureOptions> = {
+    diagnosticsEnabled: true,
+    hoverEnabled: true,
+    completionEnabled: true,
+    definitionEnabled: true,
+    renameEnabled: true,
+    codeActionsEnabled: true,
+    signatureHelpEnabled: true,
+    signatureActivateOnTyping: false,
+    signatureHelpOptions: { position: "below" },
+};
+
+interface FakeClientOverrides {
+    capabilities?: LSP.ServerCapabilities;
+    codeActions?: (LSP.Command | LSP.CodeAction)[] | null;
+}
+
+function createFakeClient(overrides: FakeClientOverrides = {}) {
+    return {
+        ready: true,
+        capabilities: overrides.capabilities ?? {
+            codeActionProvider: { resolveProvider: true },
+        },
+        dynamicCapabilities: new Map(),
+        hasCapability: LanguageServerClient.prototype.hasCapability,
+        initializePromise: Promise.resolve(),
+        onNotification: vi.fn().mockReturnValue(() => {}),
+        textDocumentDidOpen: vi.fn().mockResolvedValue(undefined),
+        textDocumentDidChange: vi.fn().mockResolvedValue(undefined),
+        textDocumentDidClose: vi.fn().mockResolvedValue(undefined),
+        textDocumentCodeAction: vi
+            .fn()
+            .mockResolvedValue(overrides.codeActions ?? null),
+        codeActionResolve: vi.fn(),
+        // biome-ignore lint/suspicious/noExplicitAny: partial stub of the client
+    } as any as LanguageServerClient;
+}
+
+function createView(doc: string): EditorView {
+    const view = new EditorView({
+        state: EditorState.create({ doc }),
+        parent: document.createElement("div"),
+    });
+    return view;
+}
+
+function createPlugin(
+    view: EditorView,
+    client = createFakeClient(),
+    options: Partial<
+        ConstructorParameters<typeof LanguageServerPlugin>[0]
+    > = {},
+) {
+    return new LanguageServerPlugin({
+        client,
+        documentUri: DOCUMENT_URI,
+        languageId: "typescript",
+        view,
+        featureOptions: { ...featureOptions },
+        ...options,
+    });
+}
+
+function editReplacing(range: LSP.Range, newText: string): LSP.WorkspaceEdit {
+    return { changes: { [DOCUMENT_URI]: [{ range, newText }] } };
+}
+
+const range = (
+    startLine: number,
+    startChar: number,
+    endLine: number,
+    endChar: number,
+): LSP.Range => ({
+    start: { line: startLine, character: startChar },
+    end: { line: endLine, character: endChar },
+});
+
+async function flushTicks(count = 5) {
+    for (let i = 0; i < count; i++) {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+}
+
+afterEach(() => {
+    document.body.innerHTML = "";
+});
+
+describe("applyCodeAction / codeAction/resolve", () => {
+    it("resolves an action with neither edit nor command before applying", async () => {
+        const client = createFakeClient();
+        client.codeActionResolve = vi.fn().mockResolvedValue({
+            title: "Fix it",
+            kind: "quickfix",
+            edit: editReplacing(range(0, 0, 0, 5), "fixed"),
+        });
+        const view = createView("hello world");
+        const plugin = createPlugin(view, client);
+
+        const lazyAction: LSP.CodeAction = {
+            title: "Fix it",
+            kind: "quickfix",
+        };
+        await plugin.applyCodeAction(lazyAction);
+
+        expect(client.codeActionResolve).toHaveBeenCalledWith(lazyAction);
+        expect(view.state.doc.toString()).toBe("fixed world");
+    });
+
+    it("does not resolve an action that already carries an edit", async () => {
+        const client = createFakeClient();
+        const view = createView("hello world");
+        const plugin = createPlugin(view, client);
+
+        await plugin.applyCodeAction({
+            title: "Fix it",
+            edit: editReplacing(range(0, 0, 0, 5), "fixed"),
+        });
+
+        expect(client.codeActionResolve).not.toHaveBeenCalled();
+        expect(view.state.doc.toString()).toBe("fixed world");
+    });
+
+    it("does not resolve when the server lacks resolveProvider", async () => {
+        const client = createFakeClient({
+            capabilities: { codeActionProvider: true },
+        });
+        const view = createView("hello world");
+        const plugin = createPlugin(view, client);
+
+        await plugin.applyCodeAction({ title: "Fix it" });
+
+        expect(client.codeActionResolve).not.toHaveBeenCalled();
+        expect(
+            document.querySelector(".cm-error-message")?.textContent,
+        ).toContain("Fix it");
+        expect(view.state.doc.toString()).toBe("hello world");
+    });
+
+    it("never resolves bare commands", async () => {
+        const client = createFakeClient();
+        const view = createView("hello world");
+        const plugin = createPlugin(view, client);
+
+        await plugin.applyCodeAction({ title: "Run", command: "test.run" });
+
+        expect(client.codeActionResolve).not.toHaveBeenCalled();
+        expect(view.state.doc.toString()).toBe("hello world");
+    });
+
+    it("falls back to the original action when resolve rejects", async () => {
+        const consoleSpy = vi
+            .spyOn(console, "error")
+            .mockImplementation(() => {});
+        const client = createFakeClient();
+        client.codeActionResolve = vi.fn().mockRejectedValue(new Error("boom"));
+        const view = createView("hello world");
+        const plugin = createPlugin(view, client);
+
+        await expect(
+            plugin.applyCodeAction({ title: "Fix it" }),
+        ).resolves.toBeUndefined();
+
+        expect(document.querySelector(".cm-error-message")).not.toBeNull();
+        expect(view.state.doc.toString()).toBe("hello world");
+        consoleSpy.mockRestore();
+    });
+
+    it("applies edits delivered via documentChanges", async () => {
+        const client = createFakeClient();
+        const view = createView("hello world");
+        const plugin = createPlugin(view, client);
+
+        await plugin.applyCodeAction({
+            title: "Fix it",
+            edit: {
+                documentChanges: [
+                    {
+                        textDocument: { uri: DOCUMENT_URI, version: 1 },
+                        edits: [
+                            { range: range(0, 6, 0, 11), newText: "there" },
+                        ],
+                    },
+                ],
+            },
+        });
+
+        expect(view.state.doc.toString()).toBe("hello there");
+    });
+});
+
+describe("requestCodeActionsAtSelection", () => {
+    it("sends the selection range and overlapping diagnostics in context", async () => {
+        const client = createFakeClient({ codeActions: [] });
+        const view = createView("hello world");
+        const plugin = createPlugin(view, client);
+
+        // Plugin-created diagnostics echo the original LSP diagnostic
+        const lspDiagnostic: LSP.Diagnostic = {
+            range: range(0, 0, 0, 5),
+            message: "bad greeting",
+            code: "E123",
+            source: "tsserver",
+        };
+        view.dispatch(
+            setDiagnostics(view.state, [
+                {
+                    from: 0,
+                    to: 5,
+                    severity: "error",
+                    message: "bad greeting",
+                    lspDiagnostic,
+                    // biome-ignore lint/suspicious/noExplicitAny: extra field carried on the lint diagnostic
+                } as any,
+                {
+                    // Outside the selection
+                    from: 6,
+                    to: 11,
+                    severity: "warning",
+                    message: "elsewhere",
+                },
+            ]),
+        );
+        view.dispatch({ selection: { anchor: 1, head: 3 } });
+
+        await plugin.requestCodeActionsAtSelection(view);
+
+        expect(client.textDocumentCodeAction).toHaveBeenCalledTimes(1);
+        expect(client.textDocumentCodeAction).toHaveBeenCalledWith({
+            textDocument: { uri: DOCUMENT_URI },
+            range: range(0, 1, 0, 3),
+            context: {
+                diagnostics: [
+                    expect.objectContaining({
+                        code: "E123",
+                        message: "bad greeting",
+                        range: range(0, 0, 0, 5),
+                    }),
+                ],
+            },
+        });
+    });
+
+    it("passes the only filter through", async () => {
+        const client = createFakeClient({ codeActions: [] });
+        const view = createView("hello world");
+        const plugin = createPlugin(view, client);
+
+        await plugin.requestCodeActions(view, range(0, 0, 0, 11), [
+            "source.organizeImports",
+        ]);
+
+        expect(client.textDocumentCodeAction).toHaveBeenCalledWith(
+            expect.objectContaining({
+                context: expect.objectContaining({
+                    only: ["source.organizeImports"],
+                }),
+            }),
+        );
+    });
+
+    it("returns null when code actions are disabled", async () => {
+        const client = createFakeClient({ codeActions: [] });
+        const view = createView("hello world");
+        const plugin = createPlugin(view, client);
+        plugin.featureOptions.codeActionsEnabled = false;
+
+        const result = await plugin.requestCodeActionsAtSelection(view);
+
+        expect(result).toBeNull();
+        expect(client.textDocumentCodeAction).not.toHaveBeenCalled();
+    });
+});
+
+describe("batched diagnostics code actions", () => {
+    it("sends exactly one codeAction request for N diagnostics", async () => {
+        const diagnostics: LSP.Diagnostic[] = [
+            { range: range(0, 0, 0, 5), message: "first" },
+            { range: range(0, 6, 0, 11), message: "second" },
+            { range: range(0, 2, 0, 4), message: "third" },
+        ];
+        const client = createFakeClient({ codeActions: [] });
+        const view = createView("hello world");
+        const plugin = createPlugin(view, client);
+
+        await plugin.processDiagnostics({ uri: DOCUMENT_URI, diagnostics });
+
+        expect(client.textDocumentCodeAction).toHaveBeenCalledTimes(1);
+        expect(client.textDocumentCodeAction).toHaveBeenCalledWith({
+            textDocument: { uri: DOCUMENT_URI },
+            range: range(0, 0, 0, 11),
+            context: { diagnostics },
+        });
+    });
+
+    it("distributes actions to diagnostics by range overlap", async () => {
+        const first: LSP.Diagnostic = {
+            range: range(0, 0, 0, 5),
+            message: "first",
+        };
+        const second: LSP.Diagnostic = {
+            range: range(0, 6, 0, 11),
+            message: "second",
+        };
+        const client = createFakeClient({
+            codeActions: [
+                {
+                    title: "Fix first",
+                    kind: "quickfix",
+                    diagnostics: [first],
+                },
+            ],
+        });
+        const view = createView("hello world");
+        const plugin = createPlugin(view, client);
+
+        // biome-ignore lint/suspicious/noExplicitAny: reach the private setter
+        const setOwnDiagnostics = vi.spyOn(plugin as any, "setOwnDiagnostics");
+        await plugin.processDiagnostics({
+            uri: DOCUMENT_URI,
+            diagnostics: [first, second],
+        });
+
+        const cmDiagnostics = setOwnDiagnostics.mock.calls[0][0] as {
+            actions?: { name: string }[];
+        }[];
+        expect(cmDiagnostics).toHaveLength(2);
+        expect(cmDiagnostics[0].actions?.map((a) => a.name)).toEqual([
+            "Fix first",
+        ]);
+        expect(cmDiagnostics[1].actions).toBeUndefined();
+    });
+
+    it("still publishes diagnostics when the codeAction request fails", async () => {
+        const consoleSpy = vi
+            .spyOn(console, "error")
+            .mockImplementation(() => {});
+        const client = createFakeClient();
+        client.textDocumentCodeAction = vi
+            .fn()
+            .mockRejectedValue(new Error("boom"));
+        const view = createView("hello world");
+        const plugin = createPlugin(view, client);
+
+        // biome-ignore lint/suspicious/noExplicitAny: reach the private setter
+        const setOwnDiagnostics = vi.spyOn(plugin as any, "setOwnDiagnostics");
+        await plugin.processDiagnostics({
+            uri: DOCUMENT_URI,
+            diagnostics: [{ range: range(0, 0, 0, 5), message: "first" }],
+        });
+
+        expect(setOwnDiagnostics).toHaveBeenCalledTimes(1);
+        expect(setOwnDiagnostics.mock.calls[0][0]).toHaveLength(1);
+        consoleSpy.mockRestore();
+    });
+});
+
+describe("code action menu", () => {
+    const menuActions: LSP.CodeAction[] = [
+        {
+            title: "Fix greeting",
+            kind: "quickfix",
+            edit: editReplacing(range(0, 0, 0, 5), "howdy"),
+        },
+        {
+            title: "Unavailable refactor",
+            kind: "refactor.rewrite",
+            disabled: { reason: "not applicable here" },
+        },
+    ];
+
+    it("renders actions with kind suffixes and disabled state", async () => {
+        const client = createFakeClient({ codeActions: menuActions });
+        const view = createView("hello world");
+        const plugin = createPlugin(view, client);
+
+        const shown = await plugin.showCodeActionsMenu(view);
+
+        expect(shown).toBe(true);
+        const menu = document.querySelector(".cm-code-action-menu");
+        expect(menu).not.toBeNull();
+        const items = [
+            ...(menu?.querySelectorAll<HTMLButtonElement>(
+                ".cm-code-action-item",
+            ) ?? []),
+        ];
+        expect(items.map((i) => i.textContent)).toEqual([
+            "Fix greetingquickfix",
+            "Unavailable refactorrefactor.rewrite",
+        ]);
+        expect(items[0].disabled).toBe(false);
+        expect(items[1].disabled).toBe(true);
+        expect(items[1].title).toBe("not applicable here");
+    });
+
+    it("applies the selected action on Enter and closes the menu", async () => {
+        const client = createFakeClient({ codeActions: menuActions });
+        const view = createView("hello world");
+        const plugin = createPlugin(view, client);
+
+        await plugin.showCodeActionsMenu(view);
+        const menu = document.querySelector(".cm-code-action-menu");
+        menu?.dispatchEvent(
+            new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+        );
+        await flushTicks();
+
+        expect(view.state.doc.toString()).toBe("howdy world");
+        expect(document.querySelector(".cm-code-action-menu")).toBeNull();
+    });
+
+    it("dismisses without applying on Escape", async () => {
+        const client = createFakeClient({ codeActions: menuActions });
+        const view = createView("hello world");
+        const plugin = createPlugin(view, client);
+
+        await plugin.showCodeActionsMenu(view);
+        const menu = document.querySelector(".cm-code-action-menu");
+        menu?.dispatchEvent(
+            new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+        );
+        await flushTicks();
+
+        expect(view.state.doc.toString()).toBe("hello world");
+        expect(document.querySelector(".cm-code-action-menu")).toBeNull();
+    });
+
+    it("dismisses on outside mousedown", async () => {
+        const client = createFakeClient({ codeActions: menuActions });
+        const view = createView("hello world");
+        const plugin = createPlugin(view, client);
+
+        await plugin.showCodeActionsMenu(view);
+        document.body.dispatchEvent(
+            new MouseEvent("mousedown", { bubbles: true }),
+        );
+
+        expect(document.querySelector(".cm-code-action-menu")).toBeNull();
+    });
+
+    it("hands the actions to a host renderMenu override instead of rendering", async () => {
+        const client = createFakeClient({ codeActions: menuActions });
+        const renderMenu = vi.fn();
+        const view = createView("hello world");
+        const plugin = createPlugin(view, client, {
+            codeActionsConfig: { renderMenu },
+        });
+
+        const shown = await plugin.showCodeActionsMenu(view);
+
+        expect(shown).toBe(true);
+        expect(document.querySelector(".cm-code-action-menu")).toBeNull();
+        expect(renderMenu).toHaveBeenCalledTimes(1);
+        const [actions, apply] = renderMenu.mock.calls[0];
+        expect(actions).toEqual(menuActions);
+
+        await apply(actions[0]);
+        expect(view.state.doc.toString()).toBe("howdy world");
+    });
+
+    it("shows a message when no actions are available", async () => {
+        const client = createFakeClient({ codeActions: [] });
+        const view = createView("hello world");
+        const plugin = createPlugin(view, client);
+
+        const shown = await plugin.showCodeActionsMenu(view);
+
+        expect(shown).toBe(false);
+        expect(document.querySelector(".cm-code-action-menu")).toBeNull();
+        expect(
+            document.querySelector(".cm-error-message")?.textContent,
+        ).toContain("No code actions available");
+    });
+});

--- a/src/__tests__/language-server-plugin.test.ts
+++ b/src/__tests__/language-server-plugin.test.ts
@@ -707,9 +707,7 @@ describe("LanguageServerPlugin", () => {
             });
 
             // Avoid real code-action requests during diagnostic processing
-            vi.spyOn(plugin as never, "requestCodeActions").mockResolvedValue(
-                undefined,
-            );
+            mockClient.textDocumentCodeAction = vi.fn().mockResolvedValue(null);
 
             vi.clearAllMocks();
         });

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export {
 } from "./plugin.js";
 export {
     LanguageServerClient,
+    type CodeActionsConfig,
     type ServerRequestHandler,
 } from "./lsp.js";
 export {

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -28,6 +28,7 @@ export interface LSPRequestMap {
         LSP.CodeActionParams,
         (LSP.Command | LSP.CodeAction)[] | null,
     ];
+    "codeAction/resolve": [LSP.CodeAction, LSP.CodeAction];
     "textDocument/rename": [LSP.RenameParams, LSP.WorkspaceEdit | null];
     "textDocument/prepareRename": [
         LSP.PrepareRenameParams,
@@ -147,6 +148,23 @@ export interface KeyboardShortcuts {
     goToDefinition?: string;
     /** Keyboard shortcut for signature help (default: Ctrl/Cmd+Shift+Space) */
     signatureHelp?: string;
+    /** Keyboard shortcut for the code action menu (default: Ctrl/Cmd+.) */
+    codeActions?: string;
+}
+
+/**
+ * Configuration for the cursor-triggered code action menu
+ */
+export interface CodeActionsConfig {
+    /**
+     * Replaces the built-in menu: the host renders the actions and calls
+     * `apply` with the chosen one (resolve and edit/command application
+     * happen inside `apply`).
+     */
+    renderMenu?: (
+        actions: (LSP.Command | LSP.CodeAction)[],
+        apply: (action: LSP.Command | LSP.CodeAction) => Promise<void>,
+    ) => void;
 }
 
 /**
@@ -201,6 +219,8 @@ export interface LanguageServerOptions extends FeatureOptions {
     languageId?: string;
     /** Configuration for keyboard shortcuts */
     keyboardShortcuts?: KeyboardShortcuts;
+    /** Configuration for the code action menu */
+    codeActionsConfig?: CodeActionsConfig;
     /** Callback triggered when a go-to-definition action is performed */
     onGoToDefinition?: (result: DefinitionResult) => void;
 
@@ -694,6 +714,10 @@ export class LanguageServerClient {
             params,
             this.timeout,
         );
+    }
+
+    public async codeActionResolve(action: LSP.CodeAction) {
+        return await this.request("codeAction/resolve", action, this.timeout);
     }
 
     public async textDocumentRename(params: LSP.RenameParams) {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -86,9 +86,20 @@ function comparePosition(a: LSP.Position, b: LSP.Position): number {
 }
 
 function rangesOverlap(a: LSP.Range, b: LSP.Range): boolean {
+    // LSP ranges are end-exclusive, so adjacent ranges do not overlap. Empty
+    // ranges are treated as touching points so a zero-length diagnostic still
+    // matches actions at its position.
+    const aEmpty = comparePosition(a.start, a.end) === 0;
+    const bEmpty = comparePosition(b.start, b.end) === 0;
+    if (aEmpty || bEmpty) {
+        return (
+            comparePosition(a.start, b.end) <= 0 &&
+            comparePosition(b.start, a.end) <= 0
+        );
+    }
     return (
-        comparePosition(a.start, b.end) <= 0 &&
-        comparePosition(b.start, a.end) <= 0
+        comparePosition(a.start, b.end) < 0 &&
+        comparePosition(b.start, a.end) < 0
     );
 }
 
@@ -253,6 +264,8 @@ export class LanguageServerPlugin implements PluginValue {
     private disposeListener?: () => void;
     private destroyed = false;
     private documentOpened = false;
+    /** Dismisses the currently open code action menu, if any. */
+    private closeCodeActionMenu?: () => void;
 
     constructor(opts: {
         client: LanguageServerClient;
@@ -342,6 +355,7 @@ export class LanguageServerPlugin implements PluginValue {
         this.destroyed = true;
         this.disposeListener?.();
         this.disposeListener = undefined;
+        this.closeCodeActionMenu?.();
         unregisterPlugin(this.view, this);
         this.closeDocument();
     }
@@ -1093,8 +1107,7 @@ export class LanguageServerPlugin implements PluginValue {
         if (action.edit || action.command) {
             return action;
         }
-        const provider = this.client.capabilities?.codeActionProvider;
-        if (!(typeof provider === "object" && provider.resolveProvider)) {
+        if (!this.serverSupportsCodeActionResolve()) {
             return action;
         }
         try {
@@ -1106,14 +1119,45 @@ export class LanguageServerPlugin implements PluginValue {
     }
 
     /**
+     * Whether the server can answer `codeAction/resolve`, announced either
+     * statically or via a dynamic codeAction registration.
+     */
+    private serverSupportsCodeActionResolve(): boolean {
+        const provider = this.client.capabilities?.codeActionProvider;
+        if (typeof provider === "object" && provider.resolveProvider) {
+            return true;
+        }
+        for (const registration of this.client.dynamicCapabilities.values()) {
+            if (registration.method === "textDocument/codeAction") {
+                const options = registration.registerOptions as
+                    | LSP.CodeActionRegistrationOptions
+                    | undefined;
+                if (options?.resolveProvider) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
      * Requests code actions for the current selection and presents them via
      * the host's `codeActionsConfig.renderMenu` or the built-in popup. Bound
      * to the `codeActions` keyboard shortcut.
      * @returns True when at least one action was shown
      */
     public async showCodeActionsMenu(view: EditorView): Promise<boolean> {
+        const requestState = view.state;
         const actions = await this.requestCodeActionsAtSelection(view);
         if (this.destroyed) {
+            return false;
+        }
+        // The document or selection may have moved while the request was in
+        // flight; actions for the old context must not be shown
+        if (
+            view.state.doc !== requestState.doc ||
+            !view.state.selection.main.eq(requestState.selection.main)
+        ) {
             return false;
         }
         if (!actions || actions.length === 0) {
@@ -1140,6 +1184,9 @@ export class LanguageServerPlugin implements PluginValue {
         actions: (LSP.Command | LSP.CodeAction)[],
         apply: (action: LSP.Command | LSP.CodeAction) => Promise<void>,
     ): void {
+        // Only one menu at a time
+        this.closeCodeActionMenu?.();
+
         const menu = document.createElement("div");
         menu.className = "cm-code-action-menu";
         menu.setAttribute("role", "listbox");
@@ -1152,10 +1199,13 @@ export class LanguageServerPlugin implements PluginValue {
             }
         };
         const dismiss = () => {
+            if (this.closeCodeActionMenu === dismiss) {
+                this.closeCodeActionMenu = undefined;
+            }
             menu.remove();
             document.removeEventListener("mousedown", handleOutsideMousedown);
-            view.focus();
         };
+        this.closeCodeActionMenu = dismiss;
 
         const buttons = actions.map((action) => {
             const item = document.createElement("button");
@@ -1182,6 +1232,7 @@ export class LanguageServerPlugin implements PluginValue {
             }
             item.addEventListener("click", () => {
                 dismiss();
+                view.focus();
                 void apply(action);
             });
             menu.appendChild(item);
@@ -1211,6 +1262,7 @@ export class LanguageServerPlugin implements PluginValue {
         menu.addEventListener("keydown", (event) => {
             if (event.key === "Escape") {
                 dismiss();
+                view.focus();
             } else if (event.key === "ArrowDown") {
                 move(1);
             } else if (event.key === "ArrowUp") {
@@ -1231,8 +1283,10 @@ export class LanguageServerPlugin implements PluginValue {
         // menu, just unpositioned
         const coords = view.coordsAtPos(view.state.selection.main.from);
         if (coords) {
-            menu.style.left = `${coords.left}px`;
-            menu.style.top = `${coords.bottom + 5}px`;
+            // coordsAtPos returns viewport coordinates; the menu is
+            // absolutely positioned in the page
+            menu.style.left = `${coords.left + window.scrollX}px`;
+            menu.style.top = `${coords.bottom + window.scrollY + 5}px`;
         }
 
         document.addEventListener("mousedown", handleOutsideMousedown);
@@ -1784,30 +1838,31 @@ export class LanguageServerPlugin implements PluginValue {
 
         // Handle documentChanges (preferred) if available
         if (documentChanges.length > 0) {
+            // Collect every edit for this document so multi-entry edits apply
+            // in one transaction; unsupported entries are skipped with a
+            // message instead of dropping the whole edit
+            const edits: LSP.TextEdit[] = [];
+            let skipped: string | null = null;
             for (const docChange of documentChanges) {
                 if ("textDocument" in docChange) {
-                    // This is a TextDocumentEdit
-                    const uri = docChange.textDocument.uri;
-
-                    if (uri !== this.documentUri) {
-                        showErrorMessage(
-                            view,
-                            "Multi-file edits not supported yet",
-                        );
-                        continue;
+                    if (docChange.textDocument.uri === this.documentUri) {
+                        edits.push(...docChange.edits);
+                    } else {
+                        skipped = "Multi-file edits not supported yet";
                     }
-
-                    return this.applyEdits(view, docChange.edits);
+                } else {
+                    // CreateFile, RenameFile, or DeleteFile operation
+                    skipped =
+                        "File creation, deletion, or renaming operations not supported yet";
                 }
-
-                // This is a CreateFile, RenameFile, or DeleteFile operation
-                showErrorMessage(
-                    view,
-                    "File creation, deletion, or renaming operations not supported yet",
-                );
+            }
+            if (skipped) {
+                showErrorMessage(view, skipped);
+            }
+            if (edits.length === 0) {
                 return false;
             }
-            return false;
+            return this.applyEdits(view, edits);
         }
 
         // Fall back to changes if documentChanges is not available

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -41,6 +41,7 @@ import {
 } from "./completion.js";
 import { documentUri, languageId } from "./config.js";
 import {
+    type CodeActionsConfig,
     type DefinitionResult,
     type FeatureOptions,
     LanguageServerClient,
@@ -68,6 +69,54 @@ const logger = console.log;
 
 function uniqueId() {
     return String(Date.now() + Math.random());
+}
+
+/**
+ * A bare `Command` is executed as-is; only literal `CodeAction`s may carry an
+ * edit or be sent to `codeAction/resolve`.
+ */
+function isBareCommand(
+    action: LSP.Command | LSP.CodeAction,
+): action is LSP.Command {
+    return typeof (action as LSP.Command).command === "string";
+}
+
+function comparePosition(a: LSP.Position, b: LSP.Position): number {
+    return a.line !== b.line ? a.line - b.line : a.character - b.character;
+}
+
+function rangesOverlap(a: LSP.Range, b: LSP.Range): boolean {
+    return (
+        comparePosition(a.start, b.end) <= 0 &&
+        comparePosition(b.start, a.end) <= 0
+    );
+}
+
+/**
+ * Actions that declare the diagnostics they address are matched by range
+ * overlap; actions without that metadata attach to every diagnostic.
+ */
+function actionAppliesToDiagnostic(
+    action: LSP.Command | LSP.CodeAction,
+    diagnostic: LSP.Diagnostic,
+): boolean {
+    if (isBareCommand(action)) {
+        return true;
+    }
+    const related = action.diagnostics;
+    if (!related || related.length === 0) {
+        return true;
+    }
+    return related.some((d) => rangesOverlap(d.range, diagnostic.range));
+}
+
+/**
+ * Lint diagnostic carrying the LSP diagnostic it was created from, so
+ * codeAction requests can echo the server's diagnostic (with `code`/`data`)
+ * back in their context.
+ */
+interface DiagnosticWithLSP extends Diagnostic {
+    lspDiagnostic?: LSP.Diagnostic;
 }
 
 /**
@@ -197,6 +246,10 @@ export class LanguageServerPlugin implements PluginValue {
      * Callback to render markdown content.
      */
     public markdownRenderer: (markdown: string) => string;
+    /**
+     * Configuration for the code action menu.
+     */
+    public codeActionsConfig: CodeActionsConfig | undefined;
     private disposeListener?: () => void;
     private destroyed = false;
     private documentOpened = false;
@@ -213,6 +266,7 @@ export class LanguageServerPlugin implements PluginValue {
         clientSideFiltering?: boolean;
         onGoToDefinition?: (result: DefinitionResult) => void;
         markdownRenderer?: (markdown: string) => string;
+        codeActionsConfig?: CodeActionsConfig;
     }) {
         const {
             client,
@@ -226,6 +280,7 @@ export class LanguageServerPlugin implements PluginValue {
             clientSideFiltering = false,
             onGoToDefinition,
             markdownRenderer = renderMarkdown,
+            codeActionsConfig,
         } = opts;
         this.documentVersion = 0;
         this.pluginId = uniqueId();
@@ -240,6 +295,7 @@ export class LanguageServerPlugin implements PluginValue {
         this.featureOptions = featureOptions;
         this.onGoToDefinition = onGoToDefinition;
         this.markdownRenderer = markdownRenderer;
+        this.codeActionsConfig = codeActionsConfig;
         registerPlugin(view, this);
         this.disposeListener = client.onNotification(
             this.processNotification.bind(this),
@@ -731,84 +787,19 @@ export class LanguageServerPlugin implements PluginValue {
         // server published for, even while code actions load below
         const doc = this.view.state.doc;
 
-        const diagnostics = params.diagnostics.map(
-            async ({
-                range,
-                message,
-                severity,
-                code,
-                source,
-            }): Promise<Diagnostic | null> => {
-                const from = posToOffset(doc, range.start);
-                const to = posToOffset(doc, range.end);
-                if (from == null || to == null || from > to) {
-                    // The range does not exist in this document (e.g. a
-                    // stale publish); dropping it beats misplacing it
-                    return null;
-                }
+        // One codeAction request for the whole publish; results are
+        // distributed to diagnostics by range overlap
+        let allActions: (LSP.Command | LSP.CodeAction)[] = [];
+        try {
+            allActions =
+                (await this.requestCodeActionsForDiagnostics(
+                    params.diagnostics,
+                )) ?? [];
+        } catch (error) {
+            // Diagnostics are still worth showing without their quick fixes
+            console.error("Failed to fetch code actions", error);
+        }
 
-                const actions = await this.requestCodeActions(range, [
-                    code as string,
-                ]);
-
-                const codemirrorActions = actions?.map(
-                    (action): Action => ({
-                        name:
-                            "command" in action &&
-                            typeof action.command === "object"
-                                ? action.command?.title || action.title
-                                : action.title,
-                        apply: async () => {
-                            if ("edit" in action && action.edit?.changes) {
-                                const changes =
-                                    action.edit.changes[this.documentUri];
-
-                                if (!changes) {
-                                    return;
-                                }
-
-                                this.applyEdits(this.view, changes);
-                            }
-
-                            if ("command" in action && action.command) {
-                                // TODO: Implement command execution
-                                // Execute command if present
-                                logger("Executing command:", action.command);
-                            }
-                        },
-                    }),
-                );
-
-                const baseSource = source || this.languageId;
-                const formattedSource =
-                    code != null && code !== ""
-                        ? `${baseSource}(${code})`
-                        : baseSource;
-
-                const diagnostic: Diagnostic = {
-                    from,
-                    to,
-                    severity: severityMap[severity ?? DiagnosticSeverity.Error],
-                    message: message,
-                    renderMessage: () => {
-                        const dom = document.createElement("div");
-                        if (this.allowHTMLContent) {
-                            dom.innerHTML = this.markdownRenderer(message);
-                        } else {
-                            dom.textContent = message;
-                        }
-                        return dom;
-                    },
-                    source: formattedSource,
-                    markClass: this.pluginId,
-                    actions: codemirrorActions,
-                };
-
-                return diagnostic;
-            },
-        );
-
-        const resolvedDiagnostics = await Promise.all(diagnostics);
         // Bail out if this publish is no longer current. Code actions are
         // awaited above, so by now the plugin may have been torn down, a newer
         // publish may have superseded this one, or the document may have
@@ -826,8 +817,71 @@ export class LanguageServerPlugin implements PluginValue {
         if (this.view.state.doc !== doc) {
             return;
         }
+
+        const diagnostics = params.diagnostics.map(
+            (lspDiagnostic): Diagnostic | null => {
+                const { range, message, severity, code, source } =
+                    lspDiagnostic;
+                const from = posToOffset(doc, range.start);
+                const to = posToOffset(doc, range.end);
+                if (from == null || to == null || from > to) {
+                    // The range does not exist in this document (e.g. a
+                    // stale publish); dropping it beats misplacing it
+                    return null;
+                }
+
+                const codemirrorActions = allActions
+                    .filter((action) =>
+                        actionAppliesToDiagnostic(action, lspDiagnostic),
+                    )
+                    .map(
+                        (action): Action => ({
+                            name:
+                                "command" in action &&
+                                typeof action.command === "object"
+                                    ? action.command?.title || action.title
+                                    : action.title,
+                            apply: () => {
+                                void this.applyCodeAction(action);
+                            },
+                        }),
+                    );
+
+                const baseSource = source || this.languageId;
+                const formattedSource =
+                    code != null && code !== ""
+                        ? `${baseSource}(${code})`
+                        : baseSource;
+
+                const diagnostic: DiagnosticWithLSP = {
+                    from,
+                    to,
+                    severity: severityMap[severity ?? DiagnosticSeverity.Error],
+                    message: message,
+                    renderMessage: () => {
+                        const dom = document.createElement("div");
+                        if (this.allowHTMLContent) {
+                            dom.innerHTML = this.markdownRenderer(message);
+                        } else {
+                            dom.textContent = message;
+                        }
+                        return dom;
+                    },
+                    source: formattedSource,
+                    markClass: this.pluginId,
+                    actions:
+                        codemirrorActions.length > 0
+                            ? codemirrorActions
+                            : undefined,
+                    lspDiagnostic,
+                };
+
+                return diagnostic;
+            },
+        );
+
         this.setOwnDiagnostics(
-            resolvedDiagnostics.filter(
+            diagnostics.filter(
                 (diagnostic): diagnostic is Diagnostic => diagnostic != null,
             ),
         );
@@ -857,15 +911,60 @@ export class LanguageServerPlugin implements PluginValue {
         this.setOwnDiagnostics([]);
     }
 
-    private async requestCodeActions(
-        range: LSP.Range,
-        diagnosticCodes: string[],
+    /**
+     * One codeAction request covering a whole publish: the range spans all
+     * diagnostics and the context carries the server's diagnostics verbatim.
+     */
+    private async requestCodeActionsForDiagnostics(
+        diagnostics: LSP.Diagnostic[],
     ): Promise<(LSP.Command | LSP.CodeAction)[] | null> {
-        // Check if code actions are enabled
+        const first = diagnostics[0];
+        if (!first) {
+            return null;
+        }
         if (!this.featureOptions.codeActionsEnabled) {
             return null;
         }
+        if (
+            !(
+                this.client.ready &&
+                this.client.hasCapability("textDocument/codeAction")
+            )
+        ) {
+            return null;
+        }
 
+        let start = first.range.start;
+        let end = first.range.end;
+        for (const diagnostic of diagnostics) {
+            if (comparePosition(diagnostic.range.start, start) < 0) {
+                start = diagnostic.range.start;
+            }
+            if (comparePosition(diagnostic.range.end, end) > 0) {
+                end = diagnostic.range.end;
+            }
+        }
+
+        return await this.client.textDocumentCodeAction({
+            textDocument: { uri: this.documentUri },
+            range: { start, end },
+            context: { diagnostics },
+        });
+    }
+
+    /**
+     * Requests code actions for a range, with the overlapping diagnostics in
+     * the request context. Hosts can build custom entry points with `only`,
+     * e.g. an "Organize imports" button via `["source.organizeImports"]`.
+     */
+    public async requestCodeActions(
+        view: EditorView,
+        range: LSP.Range,
+        only?: string[],
+    ): Promise<(LSP.Command | LSP.CodeAction)[] | null> {
+        if (!this.featureOptions.codeActionsEnabled) {
+            return null;
+        }
         if (
             !(
                 this.client.ready &&
@@ -879,16 +978,271 @@ export class LanguageServerPlugin implements PluginValue {
             textDocument: { uri: this.documentUri },
             range,
             context: {
-                diagnostics: [
-                    {
-                        range,
-                        code: diagnosticCodes[0],
-                        source: this.languageId,
-                        message: "",
-                    },
-                ],
+                diagnostics: this.diagnosticsInRange(view, range),
+                ...(only ? { only } : {}),
             },
         });
+    }
+
+    /**
+     * Requests code actions for the current selection (or the empty range at
+     * the cursor), with the overlapping diagnostics in the request context.
+     */
+    public async requestCodeActionsAtSelection(
+        view: EditorView,
+    ): Promise<(LSP.Command | LSP.CodeAction)[] | null> {
+        const { from, to } = view.state.selection.main;
+        return await this.requestCodeActions(view, {
+            start: offsetToPos(view.state.doc, from),
+            end: offsetToPos(view.state.doc, to),
+        });
+    }
+
+    /**
+     * The diagnostics currently shown in the editor that overlap the given
+     * range, as LSP diagnostics. Diagnostics this plugin created echo the
+     * server's original diagnostic; others are converted from their
+     * CodeMirror shape.
+     */
+    private diagnosticsInRange(
+        view: EditorView,
+        range: LSP.Range,
+    ): LSP.Diagnostic[] {
+        const doc = view.state.doc;
+        const from = posToOffset(doc, range.start);
+        const to = posToOffset(doc, range.end);
+        if (from == null || to == null) {
+            return [];
+        }
+        const severityBack: Record<
+            NonNullable<Diagnostic["severity"]>,
+            DiagnosticSeverity
+        > = {
+            error: DiagnosticSeverity.Error,
+            warning: DiagnosticSeverity.Warning,
+            info: DiagnosticSeverity.Information,
+            hint: DiagnosticSeverity.Hint,
+        };
+        const results: LSP.Diagnostic[] = [];
+        forEachDiagnostic(view.state, (diagnostic, dFrom, dTo) => {
+            if (dFrom > to || dTo < from) {
+                return;
+            }
+            const mappedRange: LSP.Range = {
+                start: offsetToPos(doc, dFrom),
+                end: offsetToPos(doc, dTo),
+            };
+            const original = (diagnostic as DiagnosticWithLSP).lspDiagnostic;
+            if (original) {
+                results.push({ ...original, range: mappedRange });
+            } else {
+                results.push({
+                    range: mappedRange,
+                    message: diagnostic.message,
+                    severity: severityBack[diagnostic.severity],
+                    source: diagnostic.source,
+                });
+            }
+        });
+        return results;
+    }
+
+    /**
+     * Applies a code action: lazily resolves it via `codeAction/resolve` when
+     * needed, then applies its workspace edit and/or executes its command.
+     */
+    public async applyCodeAction(
+        action: LSP.Command | LSP.CodeAction,
+    ): Promise<void> {
+        const resolved = await this.resolveCodeAction(action);
+        if (this.destroyed) {
+            return;
+        }
+
+        if (isBareCommand(resolved)) {
+            // TODO: Implement command execution
+            logger("Executing command:", resolved);
+            return;
+        }
+        if (resolved.edit) {
+            await this.applyWorkspaceEdit(this.view, resolved.edit);
+        }
+        if (resolved.command) {
+            // TODO: Implement command execution
+            logger("Executing command:", resolved.command);
+        } else if (!resolved.edit) {
+            showErrorMessage(
+                this.view,
+                `Code action "${action.title}" has nothing to apply`,
+            );
+        }
+    }
+
+    /**
+     * Resolves a code action via `codeAction/resolve` — only for literal
+     * `CodeAction`s missing both `edit` and `command`, and only when the
+     * server advertises `resolveProvider`. Falls back to the original action
+     * if the request fails.
+     */
+    private async resolveCodeAction(
+        action: LSP.Command | LSP.CodeAction,
+    ): Promise<LSP.Command | LSP.CodeAction> {
+        if (isBareCommand(action)) {
+            return action;
+        }
+        if (action.edit || action.command) {
+            return action;
+        }
+        const provider = this.client.capabilities?.codeActionProvider;
+        if (!(typeof provider === "object" && provider.resolveProvider)) {
+            return action;
+        }
+        try {
+            return await this.client.codeActionResolve(action);
+        } catch (error) {
+            console.error("Failed to resolve code action", error);
+            return action;
+        }
+    }
+
+    /**
+     * Requests code actions for the current selection and presents them via
+     * the host's `codeActionsConfig.renderMenu` or the built-in popup. Bound
+     * to the `codeActions` keyboard shortcut.
+     * @returns True when at least one action was shown
+     */
+    public async showCodeActionsMenu(view: EditorView): Promise<boolean> {
+        const actions = await this.requestCodeActionsAtSelection(view);
+        if (this.destroyed) {
+            return false;
+        }
+        if (!actions || actions.length === 0) {
+            showErrorMessage(view, "No code actions available");
+            return false;
+        }
+        const apply = async (action: LSP.Command | LSP.CodeAction) => {
+            await this.applyCodeAction(action);
+        };
+        if (this.codeActionsConfig?.renderMenu) {
+            this.codeActionsConfig.renderMenu(actions, apply);
+            return true;
+        }
+        this.showDefaultCodeActionsMenu(view, actions, apply);
+        return true;
+    }
+
+    /**
+     * The built-in code action menu: a small listbox at the cursor, keyboard
+     * navigable (ArrowUp/Down, Enter, Escape), dismissed by outside clicks.
+     */
+    private showDefaultCodeActionsMenu(
+        view: EditorView,
+        actions: (LSP.Command | LSP.CodeAction)[],
+        apply: (action: LSP.Command | LSP.CodeAction) => Promise<void>,
+    ): void {
+        const menu = document.createElement("div");
+        menu.className = "cm-code-action-menu";
+        menu.setAttribute("role", "listbox");
+        menu.style.cssText =
+            "position: absolute; display: flex; flex-direction: column; padding: 2px; background: white; border: 1px solid #ddd; box-shadow: 0 2px 8px rgba(0,0,0,.15); z-index: 99;";
+
+        const handleOutsideMousedown = (event: MouseEvent) => {
+            if (!menu.contains(event.target as Node)) {
+                dismiss();
+            }
+        };
+        const dismiss = () => {
+            menu.remove();
+            document.removeEventListener("mousedown", handleOutsideMousedown);
+            view.focus();
+        };
+
+        const buttons = actions.map((action) => {
+            const item = document.createElement("button");
+            item.type = "button";
+            item.className = "cm-code-action-item";
+            item.style.cssText =
+                "display: flex; gap: 8px; align-items: baseline; padding: 4px 8px; border: none; background: none; text-align: left; cursor: pointer; font: inherit;";
+            const title = document.createElement("span");
+            title.textContent = action.title;
+            item.appendChild(title);
+            if (!isBareCommand(action) && action.kind) {
+                const kind = document.createElement("span");
+                kind.className = "cm-code-action-kind";
+                kind.style.cssText =
+                    "color: #888; font-size: 85%; margin-left: auto;";
+                kind.textContent = action.kind;
+                item.appendChild(kind);
+            }
+            if (!isBareCommand(action) && action.disabled) {
+                item.disabled = true;
+                item.title = action.disabled.reason;
+                item.style.opacity = "0.5";
+                item.style.cursor = "default";
+            }
+            item.addEventListener("click", () => {
+                dismiss();
+                void apply(action);
+            });
+            menu.appendChild(item);
+            return item;
+        });
+
+        // Roving focus keeps keystrokes out of the editor while the menu is
+        // open
+        let selected = buttons.findIndex((button) => !button.disabled);
+        const focusItem = (index: number) => {
+            selected = index;
+            buttons[index]?.focus();
+        };
+        const move = (direction: 1 | -1) => {
+            for (
+                let i = selected + direction;
+                i >= 0 && i < buttons.length;
+                i += direction
+            ) {
+                if (!buttons[i]?.disabled) {
+                    focusItem(i);
+                    return;
+                }
+            }
+        };
+        menu.tabIndex = -1;
+        menu.addEventListener("keydown", (event) => {
+            if (event.key === "Escape") {
+                dismiss();
+            } else if (event.key === "ArrowDown") {
+                move(1);
+            } else if (event.key === "ArrowUp") {
+                move(-1);
+            } else if (event.key === "Enter") {
+                const item = buttons[selected];
+                if (item && !item.disabled) {
+                    item.click();
+                }
+            } else {
+                return;
+            }
+            event.preventDefault();
+            event.stopPropagation();
+        });
+
+        // Coordinates may be unavailable (view not laid out); still open the
+        // menu, just unpositioned
+        const coords = view.coordsAtPos(view.state.selection.main.from);
+        if (coords) {
+            menu.style.left = `${coords.left}px`;
+            menu.style.top = `${coords.bottom + 5}px`;
+        }
+
+        document.addEventListener("mousedown", handleOutsideMousedown);
+        document.body.appendChild(menu);
+        if (selected === -1) {
+            // Every action is disabled; focus the menu so Escape still works
+            menu.focus();
+        } else {
+            focusItem(selected);
+        }
     }
 
     public async requestRename(
@@ -1401,12 +1755,14 @@ export class LanguageServerPlugin implements PluginValue {
     }
 
     /**
-     * Apply workspace edit from rename operation
+     * Applies a workspace edit (from rename, code actions, etc.) to the
+     * current document in a single transaction. Edits targeting other
+     * documents and file create/rename/delete operations are not supported.
      * @param view The editor view
      * @param edit The workspace edit to apply
      * @returns True if changes were applied successfully
      */
-    protected async applyRenameEdit(
+    protected async applyWorkspaceEdit(
         view: EditorView,
         edit: LSP.WorkspaceEdit | null,
     ): Promise<boolean> {
@@ -1436,7 +1792,7 @@ export class LanguageServerPlugin implements PluginValue {
                     if (uri !== this.documentUri) {
                         showErrorMessage(
                             view,
-                            "Multi-file rename not supported yet",
+                            "Multi-file edits not supported yet",
                         );
                         continue;
                     }
@@ -1458,12 +1814,20 @@ export class LanguageServerPlugin implements PluginValue {
         let applied = false;
         for (const [uri, changes] of Object.entries(changesMap)) {
             if (uri !== this.documentUri) {
-                showErrorMessage(view, "Multi-file rename not supported yet");
+                showErrorMessage(view, "Multi-file edits not supported yet");
                 continue;
             }
             applied = this.applyEdits(view, changes) || applied;
         }
         return applied;
+    }
+
+    /** @deprecated Use {@link applyWorkspaceEdit}. */
+    protected async applyRenameEdit(
+        view: EditorView,
+        edit: LSP.WorkspaceEdit | null,
+    ): Promise<boolean> {
+        return this.applyWorkspaceEdit(view, edit);
     }
 }
 
@@ -1483,6 +1847,7 @@ export function languageServerWithClient(options: LanguageServerOptions) {
         rename: "F2",
         goToDefinition: "F12",
         signatureHelp: "Mod-Shift-Space",
+        codeActions: "Mod-.",
         ...options.keyboardShortcuts,
     };
 
@@ -1522,6 +1887,7 @@ export function languageServerWithClient(options: LanguageServerOptions) {
                 clientSideFiltering: options.clientSideFiltering,
                 onGoToDefinition: options.onGoToDefinition,
                 markdownRenderer: options.markdownRenderer,
+                codeActionsConfig: options.codeActionsConfig,
             }),
     );
     const getPlugin = (view: EditorView) => view.plugin(lspViewPlugin);
@@ -1556,6 +1922,24 @@ export function languageServerWithClient(options: LanguageServerOptions) {
                         view,
                         offsetToPos(view.state.doc, pos),
                     );
+                    return true;
+                },
+            },
+            {
+                key: shortcuts.codeActions,
+                run: (view) => {
+                    const plugin = getPlugin(view);
+                    if (!(plugin && featuresOptions.codeActionsEnabled))
+                        return false;
+
+                    plugin
+                        .showCodeActionsMenu(view)
+                        .catch((error) =>
+                            showErrorMessage(
+                                view,
+                                `Code actions failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+                            ),
+                        );
                     return true;
                 },
             },


### PR DESCRIPTION
Implements plans 04 and 05.

## codeAction/resolve
- `LanguageServerClient.codeActionResolve()`; actions with neither `edit` nor `command` are resolved before applying (only when the server advertises `resolveProvider`; bare `Command`s never)
- Failed resolve falls back to the original action; an action with nothing to apply surfaces an error message
- Edits apply through a shared `applyWorkspaceEdit` (single transaction, `documentChanges` support); `applyRenameEdit` remains as a deprecated delegate

## Code action menu
- `Mod-.` (configurable via `keyboardShortcuts.codeActions`) opens a keyboard-navigable menu at the cursor: kind suffixes, disabled actions greyed with reason, ArrowUp/Down/Enter/Escape, outside-click dismissal
- `codeActionsConfig.renderMenu` lets hosts replace the UI with their own
- Public `requestCodeActions(view, range, only?)` / `requestCodeActionsAtSelection(view)` for custom entry points (e.g. organize imports)
- Diagnostics now trigger **one** batched codeAction request per publish instead of one per diagnostic; results distribute to lint entries by range overlap, and the context echoes the server's original diagnostics (preserving `code`/`data`)

Command execution remains a TODO seam for the executeCommand plan.

## Testing
- 18 new unit tests (resolve gating/fallback, selection requests, `only` filter, batching, menu rendering/keyboard/override)
- Demo mock server gained a lazily-resolved refactor and a disabled action to exercise the menu

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `codeAction/resolve` support and a cursor-triggered code action menu (Mod-.) to make fixes and refactors easier to discover and apply. Also batches code action requests and applies edits through a single workspace-edit path.

- **New Features**
  - Resolve lazy actions via `codeAction/resolve` before applying, including when `resolveProvider` is advertised via dynamic registrations; safe fallback on failure.
  - Code action menu on `Mod-.` (configurable via `keyboardShortcuts.codeActions`), keyboard navigable; dismisses on destroy/outside click, guards against in-flight doc/selection changes, and positions correctly with page scroll. Hosts can override with `codeActionsConfig.renderMenu`.
  - Public APIs: `requestCodeActions(view, range, only?)` and `requestCodeActionsAtSelection(view)`.

- **Refactors**
  - Batch to one `textDocument/codeAction` request per diagnostics publish and distribute results by range overlap (end‑exclusive; zero-length diagnostics match); context echoes original diagnostics.
  - Apply edits via `applyWorkspaceEdit` (single transaction); collects all `documentChanges` entries for the current document, supports `changes`, and shows messages for unsupported multi-file/file ops. `applyRenameEdit` remains as a deprecated delegate.
  - Updated README (self-contained organize-imports example) and mock server; added unit tests.

<sup>Written for commit 179300cbccf901d6e02169e15e86c73708b31bdc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marimo-team/codemirror-languageserver/pull/83?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

