### PR TITLE
fix(demo): build ty_wasm against ruff's pinned toolchain; add ty hover + completion

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -53,10 +53,9 @@ jobs:
       - name: 📥 Install dependencies
         run: pnpm install --ignore-scripts --frozen-lockfile
 
-      # Non-fatal: if the Rust build fails, the demo still deploys Ruff-only
-      # (demo/python/worker.ts falls back when ty_wasm is absent).
+      # Fail the deploy if ty_wasm doesn't build rather than silently shipping
+      # the Ruff-only fallback (demo/python/worker.ts).
       - name: 🦀 Build ty_wasm
-        continue-on-error: true
         run: pnpm build:ty-wasm
 
       - name: 🛠️ Build project

--- a/demo/python/tyServer.ts
+++ b/demo/python/tyServer.ts
@@ -30,6 +30,22 @@ interface TyDiagnostic {
 interface TyFileHandle {
     path(): string;
 }
+interface TyHover {
+    markdown: string;
+    range: TyRange;
+}
+interface TyCompletion {
+    name: string;
+    kind?: number;
+    detail?: string;
+    documentation?: string;
+    insert_text?: string;
+    additional_text_edits?: TyTextEdit[];
+}
+// ty positions are 1-indexed {line, column}; LSP positions are 0-indexed.
+interface TyPositionCtor {
+    new (line: number, column: number): TyPosition;
+}
 export interface TyWorkspace {
     openFile(path: string, contents: string): TyFileHandle;
     updateFile(handle: TyFileHandle, contents: string): void;
@@ -40,6 +56,8 @@ export interface TyWorkspace {
         handle: TyFileHandle,
         diagnostic: TyDiagnostic,
     ): TyCodeAction[] | undefined;
+    hover(handle: TyFileHandle, position: TyPosition): TyHover | undefined;
+    completions(handle: TyFileHandle, position: TyPosition): TyCompletion[];
 }
 
 enum TySeverity {
@@ -55,11 +73,54 @@ const FILE_PATH = "main.py";
 export class TyServer {
     private handles = new Map<string, TyFileHandle>();
 
-    constructor(private workspace: TyWorkspace) {}
+    constructor(
+        private workspace: TyWorkspace,
+        private Position: TyPositionCtor,
+    ) {}
 
     setDocument(uri: string, text: string): LSP.Diagnostic[] {
         const handle = this.handle(uri, text);
         return this.diagnostics(handle);
+    }
+
+    hover(params: LSP.HoverParams): LSP.Hover | null {
+        const handle = this.handles.get(params.textDocument.uri);
+        if (!handle) {
+            return null;
+        }
+        const hover = this.workspace.hover(
+            handle,
+            toTyPosition(this.Position, params.position),
+        );
+        if (!hover) {
+            return null;
+        }
+        return {
+            contents: { kind: "markdown", value: hover.markdown },
+            range: toRange(hover.range),
+        };
+    }
+
+    completion(params: LSP.CompletionParams): LSP.CompletionItem[] {
+        const handle = this.handles.get(params.textDocument.uri);
+        if (!handle) {
+            return [];
+        }
+        const position = toTyPosition(this.Position, params.position);
+        return this.workspace.completions(handle, position).map((item) => ({
+            label: item.name,
+            // ty's CompletionKind is LSP's CompletionItemKind minus 1.
+            kind: item.kind != null ? item.kind + 1 : undefined,
+            detail: item.detail,
+            documentation: item.documentation
+                ? { kind: "markdown", value: item.documentation }
+                : undefined,
+            insertText: item.insert_text,
+            additionalTextEdits: item.additional_text_edits?.map((edit) => ({
+                range: toRange(edit.range),
+                newText: edit.new_text,
+            })),
+        }));
     }
 
     codeAction(params: LSP.CodeActionParams): LSP.CodeAction[] {
@@ -135,6 +196,13 @@ function toRange(range: TyRange): LSP.Range {
 
 function toPosition(position: TyPosition): LSP.Position {
     return { line: position.line - 1, character: position.column - 1 };
+}
+
+function toTyPosition(
+    Position: TyPositionCtor,
+    position: LSP.Position,
+): TyPosition {
+    return new Position(position.line + 1, position.character + 1);
 }
 
 function toSeverity(severity: number): LSP.DiagnosticSeverity {

--- a/demo/python/worker.ts
+++ b/demo/python/worker.ts
@@ -22,6 +22,13 @@ interface TyModule {
         positionEncoding: number,
         options: unknown,
     ) => TyWorkspace;
+    Position: new (
+        line: number,
+        column: number,
+    ) => {
+        line: number;
+        column: number;
+    };
     PositionEncoding: { Utf16: number };
 }
 
@@ -43,7 +50,7 @@ async function loadTy(): Promise<TyServer | null> {
         const ty = (await loader()) as unknown as TyModule;
         await ty.default();
         const workspace = new ty.Workspace("/", ty.PositionEncoding.Utf16, {});
-        return new TyServer(workspace);
+        return new TyServer(workspace, ty.Position);
     } catch (error) {
         console.error("Failed to load ty; continuing with Ruff only", error);
         return null;
@@ -70,7 +77,18 @@ function publish(servers: PythonServers, uri: string, text: string): void {
 
 serve({
     requests: {
-        initialize: async () => (await ready).ruff.initializeResult(),
+        initialize: async () => {
+            const servers = await ready;
+            const result = servers.ruff.initializeResult();
+            // ty (when vendored) adds hover + completion; Ruff only lints/formats.
+            if (servers.ty) {
+                result.capabilities.hoverProvider = true;
+                result.capabilities.completionProvider = {
+                    triggerCharacters: ["."],
+                };
+            }
+            return result;
+        },
         "textDocument/codeAction": async (params) => {
             const servers = await ready;
             const codeActionParams = params as LSP.CodeActionParams;
@@ -78,6 +96,14 @@ serve({
                 ...servers.ruff.codeAction(codeActionParams),
                 ...(servers.ty?.codeAction(codeActionParams) ?? []),
             ];
+        },
+        "textDocument/hover": async (params) => {
+            const servers = await ready;
+            return servers.ty?.hover(params as LSP.HoverParams) ?? null;
+        },
+        "textDocument/completion": async (params) => {
+            const servers = await ready;
+            return servers.ty?.completion(params as LSP.CompletionParams) ?? [];
         },
     },
     notifications: {

--- a/scripts/build-ty-wasm.sh
+++ b/scripts/build-ty-wasm.sh
@@ -36,6 +36,13 @@ else
     git -C "$RUFF_DIR" checkout --quiet --force --detach FETCH_HEAD
 fi
 
+# wasm-pack honors ruff's pinned rust-toolchain.toml, so the wasm target must be
+# installed for that toolchain, not just `stable`. Running rustup in the crate
+# dir picks up the pin (and installs the toolchain if absent).
+if command -v rustup >/dev/null 2>&1; then
+    (cd "$RUFF_DIR/crates/ty_wasm" && rustup target add wasm32-unknown-unknown)
+fi
+
 echo "Building ty_wasm (this compiles a large Rust project; it can take a while)..."
 wasm-pack build "$RUFF_DIR/crates/ty_wasm" --target web --out-dir "$OUT_DIR"
 


### PR DESCRIPTION
The demo silently shipped Ruff-only because wasm-pack honors ruff's pinned
rust-toolchain.toml, but only `stable` had the wasm32 target installed, so the
ty_wasm build failed and continue-on-error swallowed it.

- build-ty-wasm.sh: install the wasm target for ruff's pinned toolchain
- demo.yml: drop continue-on-error so a broken ty build fails the deploy
- tyServer/worker: wire ty's hover + completion into the Python demo


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure `ty_wasm` builds against Ruff’s pinned toolchain and fail the demo deploy if it doesn’t. Also add ty-powered hover and completion to the Python demo.

- **Bug Fixes**
  - Install `wasm32-unknown-unknown` for Ruff’s pinned toolchain in `build-ty-wasm.sh`.
  - Remove `continue-on-error` for `ty_wasm` in `demo.yml` so a broken ty build blocks deploys.

- **New Features**
  - Add ty hover and completion to the Python demo by wiring `TyServer` and `worker` to ty’s APIs.
  - Convert LSP/Ty positions and map completion kinds; advertise `hover` and `completion` capabilities when ty loads.

<sup>Written for commit 5557bfbfa7b94bf046ccd54067cdf97a2f3081d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marimo-team/codemirror-languageserver/pull/85?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

