### PR TITLE
fix: restore green CI (LSP 3.18 types + demo typo)

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,2 +1,6 @@
 [files]
 extend-exclude = ["**/*.test.ts"]
+
+[default.extend-identifiers]
+# Intentional typo in the Python demo used to show Ruff's F821 diagnostic.
+mesage = "mesage"

--- a/src/__tests__/language-server-plugin.test.ts
+++ b/src/__tests__/language-server-plugin.test.ts
@@ -42,6 +42,11 @@ vi.mock("../utils.js", () => ({
         return { line: 0, character: offset };
     }),
     eventsFromChangeSet: vi.fn().mockReturnValue([]),
+    diagnosticMessageToString: vi
+        .fn()
+        .mockImplementation((message) =>
+            typeof message === "string" ? message : message.value,
+        ),
     renderMarkdown: vi.fn().mockReturnValue(""),
     renderDocumentation: vi.fn().mockImplementation((element, contents) => {
         element.textContent =

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -53,6 +53,7 @@ import {
 } from "./lsp.js";
 import { WebSocketTransport } from "./transport.js";
 import {
+    diagnosticMessageToString,
     eventsFromChangeSet,
     isCompletionList,
     isEmptyDocumentation,
@@ -1009,7 +1010,7 @@ export class LanguageServerPlugin implements PluginValue {
                     from,
                     to,
                     severity: severityMap[severity ?? DiagnosticSeverity.Error],
-                    message: message,
+                    message: diagnosticMessageToString(message),
                     renderMessage: (view) =>
                         this.renderDiagnosticMessage(
                             view,
@@ -1104,10 +1105,11 @@ export class LanguageServerPlugin implements PluginValue {
         dom.classList.add("cm-lsp-diagnostic-message");
 
         const body = document.createElement("div");
+        const messageText = diagnosticMessageToString(message);
         if (this.allowHTMLContent) {
-            body.innerHTML = this.markdownRenderer(message);
+            body.innerHTML = this.markdownRenderer(messageText);
         } else {
-            body.textContent = message;
+            body.textContent = messageText;
         }
         dom.appendChild(body);
 
@@ -2161,7 +2163,16 @@ export class LanguageServerPlugin implements PluginValue {
             for (const docChange of documentChanges) {
                 if ("textDocument" in docChange) {
                     if (docChange.textDocument.uri === this.documentUri) {
-                        edits.push(...docChange.edits);
+                        // Snippet edits (LSP 3.18) carry a `snippet` instead
+                        // of `newText`; we can't apply them, so skip them and
+                        // keep the plain/annotated text edits.
+                        for (const docEdit of docChange.edits) {
+                            if ("newText" in docEdit) {
+                                edits.push(docEdit);
+                            } else {
+                                skipped = "Snippet edits not supported yet";
+                            }
+                        }
                     } else {
                         skipped = "Multi-file edits not supported yet";
                     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -236,6 +236,17 @@ export function isLSPMarkupContent(
     return (contents as LSP.MarkupContent).kind !== undefined;
 }
 
+/**
+ * Normalizes a diagnostic message to a plain string. LSP 3.18 widened
+ * `Diagnostic.message` to `string | MarkupContent`; we only render plain
+ * strings, so unwrap the `.value` when a MarkupContent is provided.
+ */
+export function diagnosticMessageToString(
+    message: string | LSP.MarkupContent,
+): string {
+    return typeof message === "string" ? message : message.value;
+}
+
 function isLSPMarkedStringObject(
     contents: LSP.MarkupContent | LSP.MarkedString | LSP.MarkedString[],
 ): contents is { language: string; value: string } {


### PR DESCRIPTION
Coerce `Diagnostic.message` to a string, skip LSP 3.18 snippet edits, and allowlist the intentional `mesage` demo typo to fix the failing typecheck and spelling jobs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores green CI by updating our LSP 3.18 handling and allowlisting an intentional demo typo. Fixes typecheck and spelling job failures.

- **Bug Fixes**
  - Coerce `Diagnostic.message` (`string | MarkupContent`) to a string via `diagnosticMessageToString` and use it in UI rendering.
  - Skip `SnippetTextEdit` entries when applying `documentChanges`; only apply edits with `newText`.
  - Allowlist the intentional `mesage` typo in `_typos.toml` for the Python demo.
  - Update tests to mock `diagnosticMessageToString`.

<sup>Written for commit 7ecadd8360e3b6632548ad18c0b0f6f36c1e8683. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marimo-team/codemirror-languageserver/pull/86?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

